### PR TITLE
Fix Uninitialized string offset 1 in /src/Helpers/Parser.php on line 35

### DIFF
--- a/src/Helpers/Parser.php
+++ b/src/Helpers/Parser.php
@@ -32,7 +32,7 @@ class Parser
             if ($tokens[$i][0] === T_CLASS) {
                 for ($j = $i + 1;$j < $counter;$j++) {
                     if ($tokens[$j] === '{') {
-                        $class = $tokens[$i + 2][1];
+                        $class = $tokens[$i + 2][1] ?? null;
                     }
                 }
             }


### PR DESCRIPTION
Uninitialized string offset 1 in `/vendor/dbout/wp-module-rest-api/src/Helpers/Parser.php` on line 35