### PR TITLE
🐛 Fix missing additional data with debug mode

### DIFF
--- a/src/Wrappers/RestWrapper.php
+++ b/src/Wrappers/RestWrapper.php
@@ -71,9 +71,9 @@ class RestWrapper
                 message: $rootException->getMessage(),
                 errorCode: $exception->getErrorCode(),
                 httpStatusCode: $exception->getHttpStatusCode(),
-                additionalData: [
+                additionalData: array_merge($exception->getAdditionalData(), [
                     'exception' => $rootException->getTraceAsString(),
-                ],
+                ]),
                 previous: $rootException,
             );
         }


### PR DESCRIPTION
When debug mode is enabled, the `RestWrapper` was overwriting the exception's additionalData with only the exception trace, causing any previously set additional data to be lost.          