### PR TITLE
🔒 Replace serialize/unserialize with JSON for route cache

### DIFF
--- a/src/RouteLoader.php
+++ b/src/RouteLoader.php
@@ -42,16 +42,135 @@ class RouteLoader
         $cacheKey = $this->options->cacheKey;
         $cacheRoutes = $cache->getItem($cacheKey);
         if ($cacheRoutes->isHit()) {
-            try {
-                return unserialize($cacheRoutes->get());
-            } catch (\Exception) {
+            $payload = $cacheRoutes->get();
+            $hydrated = is_string($payload) ? $this->hydrateRoutes($payload) : null;
+            if ($hydrated !== null) {
+                return $hydrated;
             }
         }
 
         $routes = $this->findRoutes();
-        $cacheRoutes->set(serialize($routes));
-        $cache->save($cacheRoutes);
+        $serialized = $this->dehydrateRoutes($routes);
+        if ($serialized !== null) {
+            $cacheRoutes->set($serialized);
+            $cache->save($cacheRoutes);
+        }
+
         return $routes;
+    }
+
+    /**
+     * @param string $payload JSON payload retrieved from the cache.
+     * @return Route[]|null Returns null when the payload is corrupted or
+     *                     does not match the expected shape; the caller is
+     *                     expected to fall back to a fresh discovery.
+     */
+    protected function hydrateRoutes(string $payload): ?array
+    {
+        $decoded = json_decode($payload, true);
+        if (!is_array($decoded)) {
+            return null;
+        }
+
+        $routes = [];
+        foreach ($decoded as $entry) {
+            if (!is_array($entry)) {
+                return null;
+            }
+
+            $namespace = $entry['namespace'] ?? null;
+            $path = $entry['path'] ?? null;
+            $rawActions = $entry['actions'] ?? null;
+            if (!is_string($namespace) || !is_string($path) || !is_array($rawActions)) {
+                return null;
+            }
+
+            $actions = [];
+            foreach ($rawActions as $rawAction) {
+                if (!is_array($rawAction)) {
+                    return null;
+                }
+
+                $className = $rawAction['className'] ?? null;
+                $methodName = $rawAction['methodName'] ?? null;
+                $methods = $rawAction['methods'] ?? null;
+                if (!is_string($className) || !is_string($methodName) || !is_array($methods)) {
+                    return null;
+                }
+
+                $actions[] = new RouteAction(
+                    $className,
+                    $methodName,
+                    array_values(array_filter($methods, 'is_string')),
+                    $rawAction['permissionCallback'] ?? null,
+                );
+            }
+
+            $routes[] = new Route($namespace, $path, $actions);
+        }
+
+        return $routes;
+    }
+
+    /**
+     * @param Route[] $routes
+     * @return string|null JSON payload, or null when at least one route uses
+     *                    a permissionCallback that cannot be safely cached
+     *                    (e.g. a Closure or a non-callable object).
+     */
+    protected function dehydrateRoutes(array $routes): ?string
+    {
+        $payload = [];
+        foreach ($routes as $route) {
+            $actions = [];
+            foreach ($route->actions as $action) {
+                if (!$this->isCacheableCallback($action->permissionCallback)) {
+                    trigger_error(sprintf(
+                        'Route %s/%s has a permissionCallback that cannot be cached (Closure or non-serializable value); the route cache will be skipped.',
+                        $route->namespace,
+                        $route->path,
+                    ), \E_USER_NOTICE);
+
+                    return null;
+                }
+
+                $actions[] = [
+                    'className' => $action->className,
+                    'methodName' => $action->methodName,
+                    'methods' => $action->methods,
+                    'permissionCallback' => $action->permissionCallback,
+                ];
+            }
+
+            $payload[] = [
+                'namespace' => $route->namespace,
+                'path' => $route->path,
+                'actions' => $actions,
+            ];
+        }
+
+        try {
+            return json_encode($payload, \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES);
+        } catch (\JsonException) {
+            return null;
+        }
+    }
+
+    /**
+     * Whether the given permission callback can be safely persisted as JSON
+     * and rebuilt as a usable callback later on.
+     */
+    protected function isCacheableCallback(mixed $callback): bool
+    {
+        if ($callback === null || is_string($callback)) {
+            return true;
+        }
+
+        return is_array($callback)
+            && count($callback) === 2
+            && isset($callback[0], $callback[1])
+            && is_string($callback[0])
+            && is_string($callback[1]);
     }
 
     /**

--- a/src/RouteLoader.php
+++ b/src/RouteLoader.php
@@ -101,7 +101,7 @@ class RouteLoader
                 $actions[] = new RouteAction(
                     $className,
                     $methodName,
-                    array_values(array_filter($methods, 'is_string')),
+                    array_values(array_filter($methods, is_string(...))),
                     $rawAction['permissionCallback'] ?? null,
                 );
             }

--- a/tests/Unit/RouteLoaderTest.php
+++ b/tests/Unit/RouteLoaderTest.php
@@ -1,0 +1,283 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpRestApi\Tests\Unit;
+
+use Dbout\WpRestApi\Route;
+use Dbout\WpRestApi\RouteAction;
+use Dbout\WpRestApi\RouteLoader;
+use Dbout\WpRestApi\RouteLoaderOptions;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * @coversDefaultClass \Dbout\WpRestApi\RouteLoader
+ */
+class RouteLoaderTest extends TestCase
+{
+    private const FIXTURE_DIR = __DIR__ . '/fixtures/RouteLoader';
+
+    /**
+     * @covers ::getRoutes
+     * @covers ::dehydrateRoutes
+     * @covers ::hydrateRoutes
+     */
+    public function testRoutesArePersistedAsJson(): void
+    {
+        $cache = new ArrayCachePool();
+        $loader = new RouteLoader(self::FIXTURE_DIR, new RouteLoaderOptions(cache: $cache));
+
+        $this->invokeGetRoutes($loader);
+
+        $stored = $cache->getItem(RouteLoaderOptions::DEFAULT_CACHE_KEY)->get();
+        $this->assertIsString($stored, 'Cache payload must be a string.');
+
+        $decoded = json_decode($stored, true);
+        $this->assertIsArray($decoded, 'Cache payload must be valid JSON.');
+        $this->assertNotEmpty($decoded);
+
+        $first = $decoded[0];
+        $this->assertSame('test-cache/v1', $first['namespace']);
+        $this->assertSame('/ping', $first['path']);
+        $this->assertCount(1, $first['actions']);
+        $this->assertSame(['GET'], $first['actions'][0]['methods']);
+    }
+
+    /**
+     * @covers ::getRoutes
+     * @covers ::hydrateRoutes
+     */
+    public function testCacheHitReturnsRoutesWithoutRescanning(): void
+    {
+        $cache = new ArrayCachePool();
+        $options = new RouteLoaderOptions(cache: $cache);
+        $loader = new RouteLoader(self::FIXTURE_DIR, $options);
+
+        $first = $this->invokeGetRoutes($loader);
+        $this->assertCount(1, $first);
+
+        $bogusLoader = new RouteLoader('/path/that/does/not/exist', $options);
+        $second = $this->invokeGetRoutes($bogusLoader);
+
+        $this->assertCount(1, $second, 'Cached routes should be returned even when discovery would fail.');
+        $this->assertEquals($first[0]->namespace, $second[0]->namespace);
+        $this->assertEquals($first[0]->path, $second[0]->path);
+        $this->assertEquals($first[0]->actions[0]->className, $second[0]->actions[0]->className);
+    }
+
+    /**
+     * @covers ::getRoutes
+     * @covers ::hydrateRoutes
+     */
+    public function testCorruptedCachePayloadFallsBackToDiscovery(): void
+    {
+        $cache = new ArrayCachePool();
+        $item = $cache->getItem(RouteLoaderOptions::DEFAULT_CACHE_KEY);
+        $item->set('{"this is": not valid json');
+        $cache->save($item);
+
+        $loader = new RouteLoader(self::FIXTURE_DIR, new RouteLoaderOptions(cache: $cache));
+        $routes = $this->invokeGetRoutes($loader);
+
+        $this->assertCount(1, $routes);
+        $this->assertSame('test-cache/v1', $routes[0]->namespace);
+
+        $rebuilt = $cache->getItem(RouteLoaderOptions::DEFAULT_CACHE_KEY)->get();
+        $this->assertIsString($rebuilt);
+        $this->assertNotSame('{"this is": not valid json', $rebuilt, 'Cache should have been overwritten with a fresh payload.');
+        $this->assertIsArray(json_decode($rebuilt, true));
+    }
+
+    /**
+     * @covers ::getRoutes
+     * @covers ::hydrateRoutes
+     */
+    public function testCachePayloadWithUnexpectedShapeFallsBack(): void
+    {
+        $cache = new ArrayCachePool();
+        $item = $cache->getItem(RouteLoaderOptions::DEFAULT_CACHE_KEY);
+        $item->set(json_encode([['namespace' => 'foo']])); // missing "path" and "actions"
+        $cache->save($item);
+
+        $loader = new RouteLoader(self::FIXTURE_DIR, new RouteLoaderOptions(cache: $cache));
+        $routes = $this->invokeGetRoutes($loader);
+
+        $this->assertCount(1, $routes);
+        $this->assertSame('test-cache/v1', $routes[0]->namespace);
+    }
+
+    /**
+     * @covers ::dehydrateRoutes
+     */
+    public function testClosurePermissionCallbackSkipsCache(): void
+    {
+        $cache = new ArrayCachePool();
+        $options = new RouteLoaderOptions(cache: $cache);
+
+        $loader = new class (self::FIXTURE_DIR, $options) extends RouteLoader {
+            protected function findRoutes(): array
+            {
+                return [
+                    new Route('demo/v1', '/closure', [
+                        new RouteAction(
+                            \Dbout\WpRestApi\Tests\Unit\fixtures\RouteLoader\PingRoute::class,
+                            'ping',
+                            ['GET'],
+                            static fn (): bool => true,
+                        ),
+                    ]),
+                ];
+            }
+        };
+
+        set_error_handler(static function (int $errno, string $errstr): bool {
+            throw new \ErrorException($errstr, $errno);
+        }, \E_USER_NOTICE);
+
+        try {
+            $this->expectException(\ErrorException::class);
+            $this->expectExceptionMessageMatches('/cannot be cached/i');
+            $this->invokeGetRoutes($loader);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertFalse($cache->getItem(RouteLoaderOptions::DEFAULT_CACHE_KEY)->isHit());
+    }
+
+    /**
+     * @return Route[]
+     */
+    private function invokeGetRoutes(RouteLoader $loader): array
+    {
+        $method = new \ReflectionMethod(RouteLoader::class, 'getRoutes');
+        $method->setAccessible(true);
+
+        /** @var Route[] $routes */
+        $routes = $method->invoke($loader);
+        return $routes;
+    }
+}
+
+/**
+ * Minimal in-memory PSR-6 cache pool for unit tests. Only the methods used
+ * by RouteLoader are implemented in a meaningful way; the rest are stubs.
+ */
+final class ArrayCachePool implements CacheItemPoolInterface
+{
+    /** @var array<string, ArrayCacheItem> */
+    private array $items = [];
+
+    public function getItem(string $key): CacheItemInterface
+    {
+        return $this->items[$key] ?? new ArrayCacheItem($key);
+    }
+
+    /** @inheritDoc */
+    public function getItems(array $keys = []): iterable
+    {
+        $out = [];
+        foreach ($keys as $key) {
+            $out[$key] = $this->getItem($key);
+        }
+        return $out;
+    }
+
+    public function hasItem(string $key): bool
+    {
+        return isset($this->items[$key]);
+    }
+
+    public function clear(): bool
+    {
+        $this->items = [];
+        return true;
+    }
+
+    public function deleteItem(string $key): bool
+    {
+        unset($this->items[$key]);
+        return true;
+    }
+
+    /** @inheritDoc */
+    public function deleteItems(array $keys): bool
+    {
+        foreach ($keys as $key) {
+            $this->deleteItem($key);
+        }
+        return true;
+    }
+
+    public function save(CacheItemInterface $item): bool
+    {
+        if (!$item instanceof ArrayCacheItem) {
+            return false;
+        }
+        $item->markHit();
+        $this->items[$item->getKey()] = $item;
+        return true;
+    }
+
+    public function saveDeferred(CacheItemInterface $item): bool
+    {
+        return $this->save($item);
+    }
+
+    public function commit(): bool
+    {
+        return true;
+    }
+}
+
+final class ArrayCacheItem implements CacheItemInterface
+{
+    private mixed $value = null;
+    private bool $hit = false;
+
+    public function __construct(private readonly string $key)
+    {
+    }
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    public function get(): mixed
+    {
+        return $this->value;
+    }
+
+    public function isHit(): bool
+    {
+        return $this->hit;
+    }
+
+    public function set(mixed $value): static
+    {
+        $this->value = $value;
+        return $this;
+    }
+
+    public function expiresAt(?\DateTimeInterface $expiration): static
+    {
+        return $this;
+    }
+
+    public function expiresAfter(\DateInterval|int|null $time): static
+    {
+        return $this;
+    }
+
+    public function markHit(): void
+    {
+        $this->hit = true;
+    }
+}

--- a/tests/Unit/fixtures/RouteLoader/PingRoute.php
+++ b/tests/Unit/fixtures/RouteLoader/PingRoute.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpRestApi\Tests\Unit\fixtures\RouteLoader;
+
+use Dbout\WpRestApi\Attributes\Action;
+use Dbout\WpRestApi\Attributes\Route;
+use Dbout\WpRestApi\Enums\Method;
+
+#[Route('test-cache/v1', '/ping')]
+class PingRoute
+{
+    #[Action(Method::GET)]
+    public function ping(): \WP_REST_Response
+    {
+        return new \WP_REST_Response(['pong' => true]);
+    }
+}


### PR DESCRIPTION
## Summary
  
  Replace `serialize()` / `unserialize()` with JSON for the PSR-6 route cache, and fix the unreachable `try/catch` block that left `RouteLoader::getRoutes()` returning `false` when the cache payload was corrupted.

  ## Why
  
  `RouteLoader::getRoutes()` deserialized the cached route list with `unserialize()`:

  ```php
  try {
      return unserialize($cacheRoutes->get());
  } catch (\Exception) {
  }
```

**Two problems:**

  1. PHP object injection risk. If the PSR-6 backend (Redis, Memcached, file cache, shared opcache…) is poisoned, an attacker can inject a serialized payload that triggers a POP gadget chain. The cached data only contains plain
  strings (class names, paths, HTTP methods) — there is no need to allow arbitrary class deserialization.
  2. Dead catch block. unserialize() does not throw exceptions; on failure it returns false. The catch never fires, so a corrupted cache leaked through as false, and register() then crashed on foreach ($routes as $route).

**What changed**

  - `RouteLoader::getRoutes()` now persists routes as JSON and validates the shape on read. Any anomaly (invalid JSON, missing/wrong-typed fields, unsupported callback) triggers a transparent fallback to findRoutes() and overwrites the cache.
  - `New hydrateRoutes(string): ?Route[]` rebuilds Route / RouteAction instances and returns null whenever the payload deviates from the expected shape — letting the caller rebuild instead of returning a half-broken list.
  - `New dehydrateRoutes(Route[]): ?string` flattens routes into plain arrays, uses JSON_THROW_ON_ERROR, and refuses to cache when a permissionCallback cannot be safely serialized (Closure, arbitrary object). Such routes still
  register normally; only the cache write is skipped, with an E_USER_NOTICE so it shows up in dev.
  - `New isCacheableCallback(mixed): bool` accepts only null, strings (class-string / function name) and [class-string, method-string] arrays.