### PR TITLE
🐛 Catch \Throwable in RestWrapper to handle PHP errors uniformly

### DIFF
--- a/src/Wrappers/RestWrapper.php
+++ b/src/Wrappers/RestWrapper.php
@@ -37,7 +37,7 @@ class RestWrapper
             $method = $classRef->getMethod($this->action->methodName);
             $dependencies = $this->collectDependencies($method, $request);
             $response = $method->invoke($classRef->newInstance(), ...$dependencies);
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             return $this->onError($exception);
         }
 
@@ -52,10 +52,10 @@ class RestWrapper
     }
 
     /**
-     * @param \Exception $exception
+     * @param \Throwable $exception
      * @return \WP_REST_Response
      */
-    protected function onError(\Exception $exception): \WP_REST_Response
+    protected function onError(\Throwable $exception): \WP_REST_Response
     {
         $rootException = $exception;
         if (!$exception instanceof RouteException) {

--- a/tests/Unit/Wrappers/RestWrapperTest.php
+++ b/tests/Unit/Wrappers/RestWrapperTest.php
@@ -10,6 +10,7 @@ namespace Dbout\WpRestApi\Tests\Unit\Wrappers;
 
 use Dbout\WpRestApi\RouteAction;
 use Dbout\WpRestApi\Tests\Unit\fixtures\RouteWithException;
+use Dbout\WpRestApi\Tests\Unit\fixtures\RouteWithFatalError;
 use Dbout\WpRestApi\Tests\Unit\fixtures\RouteWithNotFoundException;
 use Dbout\WpRestApi\Tests\Unit\fixtures\RouteWithRouteException;
 use Dbout\WpRestApi\Wrappers\RestWrapper;
@@ -79,6 +80,20 @@ class RestWrapperTest extends TestCase
             false,
             'My route exception.',
             400,
+        ];
+
+        yield 'With \TypeError and debug mode' => [
+            RouteWithFatalError::class,
+            true,
+            'My custom type error.',
+            500,
+        ];
+
+        yield 'With \TypeError and without debug mode' => [
+            RouteWithFatalError::class,
+            false,
+            'Something went wrong. Please try again.',
+            500,
         ];
     }
 

--- a/tests/Unit/fixtures/RouteWithFatalError.php
+++ b/tests/Unit/fixtures/RouteWithFatalError.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpRestApi\Tests\Unit\fixtures;
+
+class RouteWithFatalError
+{
+    /**
+     * @return never
+     * @throws \TypeError
+     */
+    public function execute(): never
+    {
+        throw new \TypeError('My custom type error.');
+    }
+}


### PR DESCRIPTION
### Summary
  
  Catch `\Throwable` (instead of only `\Exception`) inside `RestWrapper::execute()` so that PHP errors (`\TypeError`, `\ArgumentCountError`, `\AssertionError`, …) thrown from a route handler are wrapped in the same JSON envelope
   as regular exceptions.

  ### Why

  `RestWrapper::execute()` only caught `\Exception`. Any `\Error` thrown from a handler — wrong return type, missing constructor argument, failed assertion, etc. — propagated past the wrapper and produced a raw 500 (HTML in dev,
   empty body in prod). Behaviour was inconsistent across error types and broke API clients that expect JSON.

  Catching `\Throwable` does **not** hide the error in dev: when `RouteLoaderOptions::$debug` is enabled, the full message and `getTraceAsString()` are still added to the response under `error.data.exception`. In production, the
   consumer always gets the generic `fatal-error` envelope instead of leaking server internals.