### PR TITLE
🐛 Fix PermissionWrapper resolution order for non-class callbacks

### DIFF
--- a/src/Wrappers/PermissionWrapper.php
+++ b/src/Wrappers/PermissionWrapper.php
@@ -36,15 +36,17 @@ class PermissionWrapper
         }
 
         try {
-            $class = new \ReflectionClass($permissionCallback);
-            if ($class->implementsInterface(PermissionInterface::class)) {
-                /** @var PermissionInterface $instance */
-                $instance = $class->newInstance();
-                return $instance->allow($request);
+            if (is_string($permissionCallback) && class_exists($permissionCallback)) {
+                $ref = new \ReflectionClass($permissionCallback);
+                if ($ref->implementsInterface(PermissionInterface::class)) {
+                    /** @var PermissionInterface $instance */
+                    $instance = $ref->newInstance();
+                    return $instance->allow($request);
+                }
             }
 
             if (is_callable($permissionCallback)) {
-                return call_user_func($permissionCallback, $request);
+                return ($permissionCallback)($request);
             }
 
             throw new ApiException('Invalid permissionCallback argument.');

--- a/tests/Unit/Bootstrap.php
+++ b/tests/Unit/Bootstrap.php
@@ -70,6 +70,8 @@ class Bootstrap
         foreach ($paths as $path) {
             require sprintf('%s/wp-includes/%s', $this->wpDirectory, $path);
         }
+
+        require __DIR__ . '/wp-stubs.php';
     }
 }
 

--- a/tests/Unit/Wrappers/PermissionWrapperTest.php
+++ b/tests/Unit/Wrappers/PermissionWrapperTest.php
@@ -8,7 +8,11 @@
 
 namespace Dbout\WpRestApi\Tests\Unit\Wrappers;
 
+use Dbout\WpRestApi\Exceptions\ApiException;
 use Dbout\WpRestApi\RouteAction;
+use Dbout\WpRestApi\Tests\Unit\fixtures\AlwaysAllowPermission;
+use Dbout\WpRestApi\Tests\Unit\fixtures\AlwaysDenyPermission;
+use Dbout\WpRestApi\Tests\Unit\fixtures\PermissionCallbacks;
 use Dbout\WpRestApi\Wrappers\PermissionWrapper;
 use PHPUnit\Framework\TestCase;
 
@@ -24,21 +28,114 @@ class PermissionWrapperTest extends TestCase
      */
     public function testWithoutPermission(): void
     {
-        $wrapper = $this->createWrapper(new RouteAction('MyClass', 'execute', [
-            'GET',
-            'POST',
-        ], null));
-
-        $request = new \WP_REST_Request();
-        $this->assertTrue($wrapper->execute($request));
+        $wrapper = $this->createWrapper(null);
+        $this->assertTrue($wrapper->execute(new \WP_REST_Request()));
     }
 
     /**
-     * @param RouteAction $action
+     * @covers ::execute
+     */
+    public function testPermissionInterfaceClassStringAllow(): void
+    {
+        $wrapper = $this->createWrapper(AlwaysAllowPermission::class);
+        $this->assertTrue($wrapper->execute(new \WP_REST_Request()));
+    }
+
+    /**
+     * @covers ::execute
+     */
+    public function testPermissionExceptionIsConvertedToWpError(): void
+    {
+        $wrapper = $this->createWrapper(AlwaysDenyPermission::class);
+        $result = $wrapper->execute(new \WP_REST_Request());
+
+        $this->assertInstanceOf(\WP_Error::class, $result);
+        $this->assertSame('rest_forbidden', $result->get_error_code());
+        $this->assertSame('Access denied for testing.', $result->get_error_message());
+    }
+
+    /**
+     * @covers ::execute
+     */
+    public function testStringFunctionCallable(): void
+    {
+        // is_object() is a built-in function that accepts any value and
+        // returns true when the argument is an object — perfect smoke test
+        // for resolving a function-name-as-string callable.
+        $wrapper = $this->createWrapper('is_object');
+        $this->assertTrue($wrapper->execute(new \WP_REST_Request()));
+    }
+
+    /**
+     * @covers ::execute
+     */
+    public function testStringClassMethodCallable(): void
+    {
+        $wrapper = $this->createWrapper(PermissionCallbacks::class . '::allow');
+        $this->assertTrue($wrapper->execute(new \WP_REST_Request()));
+    }
+
+    /**
+     * @covers ::execute
+     */
+    public function testArrayCallable(): void
+    {
+        $wrapper = $this->createWrapper([PermissionCallbacks::class, 'allow']);
+        $this->assertTrue($wrapper->execute(new \WP_REST_Request()));
+
+        $wrapper = $this->createWrapper([PermissionCallbacks::class, 'deny']);
+        $this->assertFalse($wrapper->execute(new \WP_REST_Request()));
+    }
+
+    /**
+     * @covers ::execute
+     */
+    public function testClosureCallable(): void
+    {
+        $wrapper = $this->createWrapper(static fn (\WP_REST_Request $request): bool => true);
+        $this->assertTrue($wrapper->execute(new \WP_REST_Request()));
+
+        $wrapper = $this->createWrapper(static fn (\WP_REST_Request $request): bool => false);
+        $this->assertFalse($wrapper->execute(new \WP_REST_Request()));
+    }
+
+    /**
+     * @covers ::execute
+     */
+    public function testInvalidCallbackThrowsApiException(): void
+    {
+        $wrapper = $this->createWrapper(42);
+
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessage('Invalid permissionCallback argument.');
+
+        $wrapper->execute(new \WP_REST_Request());
+    }
+
+    /**
+     * @covers ::execute
+     */
+    public function testUnknownStringCallbackThrowsApiException(): void
+    {
+        $wrapper = $this->createWrapper('this_function_does_not_exist_anywhere');
+
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessage('Invalid permissionCallback argument.');
+
+        $wrapper->execute(new \WP_REST_Request());
+    }
+
+    /**
+     * @param mixed $permissionCallback
      * @return PermissionWrapper
      */
-    protected function createWrapper(RouteAction $action): PermissionWrapper
+    protected function createWrapper(mixed $permissionCallback): PermissionWrapper
     {
-        return new PermissionWrapper($action);
+        return new PermissionWrapper(new RouteAction(
+            'MyClass',
+            'execute',
+            ['GET', 'POST'],
+            $permissionCallback,
+        ));
     }
 }

--- a/tests/Unit/fixtures/AlwaysAllowPermission.php
+++ b/tests/Unit/fixtures/AlwaysAllowPermission.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpRestApi\Tests\Unit\fixtures;
+
+use Dbout\WpRestApi\Permissions\PermissionInterface;
+
+class AlwaysAllowPermission implements PermissionInterface
+{
+    public function allow(\WP_REST_Request $request): bool
+    {
+        return true;
+    }
+}

--- a/tests/Unit/fixtures/AlwaysDenyPermission.php
+++ b/tests/Unit/fixtures/AlwaysDenyPermission.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpRestApi\Tests\Unit\fixtures;
+
+use Dbout\WpRestApi\Exceptions\PermissionException;
+use Dbout\WpRestApi\Permissions\PermissionInterface;
+
+class AlwaysDenyPermission implements PermissionInterface
+{
+    public function allow(\WP_REST_Request $request): bool
+    {
+        throw new PermissionException('Access denied for testing.');
+    }
+}

--- a/tests/Unit/fixtures/PermissionCallbacks.php
+++ b/tests/Unit/fixtures/PermissionCallbacks.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpRestApi\Tests\Unit\fixtures;
+
+class PermissionCallbacks
+{
+    public static function allow(\WP_REST_Request $request): bool
+    {
+        return true;
+    }
+
+    public static function deny(\WP_REST_Request $request): bool
+    {
+        return false;
+    }
+}

--- a/tests/Unit/wp-stubs.php
+++ b/tests/Unit/wp-stubs.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Stubs for WordPress pluggable functions not loaded by the unit-test
+ * bootstrap. They give the SUT enough surface to construct WP_Error
+ * responses without dragging in pluggable.php and its dependencies.
+ */
+
+if (!function_exists('is_user_logged_in')) {
+    function is_user_logged_in(): bool
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
### Summary
  
  Fix `PermissionWrapper::execute()` so that every callable form documented in the public API works at runtime — function-name strings, array callables, closures — not only `PermissionInterface` class-strings.

  ### Why
  
  `ReflectionClass` was instantiated **before** the `is_callable()` check. As a result:

  - `'is_user_logged_in'` (function name) → `ReflectionException`.
  - `[MyClass::class, 'check']` (array callable) → `TypeError` (`ReflectionClass` requires `string|object`).
  - closures fell through and worked by accident, but only because `Closure` is a class — fragile.

  The `catch (PermissionException)` block did not catch any of these, so they propagated as raw 500s.