### PR TITLE
⚡️ perf: cache reflection metadata to skip per-request lookups

### DIFF
--- a/src/Wrappers/ParameterDescriptor.php
+++ b/src/Wrappers/ParameterDescriptor.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpRestApi\Wrappers;
+
+/**
+ * Pre-resolved metadata about a single route handler parameter, cached
+ * by ReflectionCache so that we don't pay the reflection cost on every
+ * request. Lives in-process; rebuilt once per parameter per worker.
+ */
+final class ParameterDescriptor
+{
+    /**
+     * @param string $name Declared parameter name (used to look up request params).
+     * @param int $position Zero-based parameter position in the method signature.
+     * @param string|null $typeName FQCN or scalar type name; null when the parameter
+     *                              has no type or a non-named type (intersection / union).
+     */
+    public function __construct(
+        public readonly string $name,
+        public readonly int $position,
+        public readonly ?string $typeName,
+    ) {
+    }
+}

--- a/src/Wrappers/PermissionWrapper.php
+++ b/src/Wrappers/PermissionWrapper.php
@@ -37,10 +37,9 @@ class PermissionWrapper
 
         try {
             if (is_string($permissionCallback) && class_exists($permissionCallback)) {
-                $ref = new \ReflectionClass($permissionCallback);
-                if ($ref->implementsInterface(PermissionInterface::class)) {
+                if (ReflectionCache::implementsPermissionInterface($permissionCallback)) {
                     /** @var PermissionInterface $instance */
-                    $instance = $ref->newInstance();
+                    $instance = new $permissionCallback();
                     return $instance->allow($request);
                 }
             }

--- a/src/Wrappers/PermissionWrapper.php
+++ b/src/Wrappers/PermissionWrapper.php
@@ -36,12 +36,10 @@ class PermissionWrapper
         }
 
         try {
-            if (is_string($permissionCallback) && class_exists($permissionCallback)) {
-                if (ReflectionCache::implementsPermissionInterface($permissionCallback)) {
-                    /** @var PermissionInterface $instance */
-                    $instance = new $permissionCallback();
-                    return $instance->allow($request);
-                }
+            if (is_string($permissionCallback) && class_exists($permissionCallback) && ReflectionCache::implementsPermissionInterface($permissionCallback)) {
+                /** @var PermissionInterface $instance */
+                $instance = new $permissionCallback();
+                return $instance->allow($request);
             }
 
             if (is_callable($permissionCallback)) {

--- a/src/Wrappers/ReflectionCache.php
+++ b/src/Wrappers/ReflectionCache.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpRestApi\Wrappers;
+
+use Dbout\WpRestApi\Permissions\PermissionInterface;
+
+/**
+ * In-process memoization layer for the reflection lookups performed on
+ * every REST request. Class metadata is constant for a worker's lifetime,
+ * so we resolve it once and reuse the result.
+ */
+final class ReflectionCache
+{
+    /** @var array<string, ParameterDescriptor[]> */
+    private static array $parameters = [];
+
+    /** @var array<class-string, bool> */
+    private static array $implementsPermissionInterface = [];
+
+    /**
+     * Returns the resolved parameter descriptors for the given method.
+     *
+     * @param class-string $class
+     * @throws \ReflectionException
+     * @return ParameterDescriptor[]
+     */
+    public static function parameters(string $class, string $method): array
+    {
+        $key = $class . '::' . $method;
+        if (isset(self::$parameters[$key])) {
+            return self::$parameters[$key];
+        }
+
+        $reflection = new \ReflectionMethod($class, $method);
+        $descriptors = [];
+        foreach ($reflection->getParameters() as $parameter) {
+            $type = $parameter->getType();
+            $descriptors[] = new ParameterDescriptor(
+                name: $parameter->getName(),
+                position: $parameter->getPosition(),
+                typeName: $type instanceof \ReflectionNamedType ? $type->getName() : null,
+            );
+        }
+
+        return self::$parameters[$key] = $descriptors;
+    }
+
+    /**
+     * Whether the given class implements PermissionInterface.
+     *
+     * @param class-string $class
+     */
+    public static function implementsPermissionInterface(string $class): bool
+    {
+        if (isset(self::$implementsPermissionInterface[$class])) {
+            return self::$implementsPermissionInterface[$class];
+        }
+
+        return self::$implementsPermissionInterface[$class] =
+            (new \ReflectionClass($class))->implementsInterface(PermissionInterface::class);
+    }
+
+    /**
+     * Clear the cache. Intended for tests that swap class definitions
+     * between scenarios; production code never needs this.
+     */
+    public static function clear(): void
+    {
+        self::$parameters = [];
+        self::$implementsPermissionInterface = [];
+    }
+}

--- a/src/Wrappers/RestWrapper.php
+++ b/src/Wrappers/RestWrapper.php
@@ -33,10 +33,11 @@ class RestWrapper
     public function execute(\WP_REST_Request $request): \WP_REST_Response
     {
         try {
-            $classRef = new \ReflectionClass($this->action->className);
-            $method = $classRef->getMethod($this->action->methodName);
-            $dependencies = $this->collectDependencies($method, $request);
-            $response = $method->invoke($classRef->newInstance(), ...$dependencies);
+            $className = $this->action->className;
+            $methodName = $this->action->methodName;
+            $dependencies = $this->collectDependencies($className, $methodName, $request);
+            $instance = new $className();
+            $response = $instance->{$methodName}(...$dependencies);
         } catch (\Throwable $exception) {
             return $this->onError($exception);
         }
@@ -85,48 +86,50 @@ class RestWrapper
     }
 
     /**
-     * @param \ReflectionMethod $method
+     * @param class-string $className
+     * @param string $methodName
      * @param \WP_REST_Request $request
+     * @throws \ReflectionException
      * @return array<int, mixed>
      */
-    protected function collectDependencies(\ReflectionMethod $method, \WP_REST_Request $request): array
+    protected function collectDependencies(string $className, string $methodName, \WP_REST_Request $request): array
     {
         $dependencies = [];
-        foreach ($method->getParameters() as $parameter) {
-            $type = $parameter->getType();
-            if (!$type instanceof \ReflectionNamedType) {
+        $requestClass = get_class($request);
+
+        foreach (ReflectionCache::parameters($className, $methodName) as $descriptor) {
+            if ($descriptor->typeName === null) {
                 continue;
             }
 
-            if ($type->getName() === get_class($request)) {
-                $dependencies[$parameter->getPosition()] = $request;
+            if ($descriptor->typeName === $requestClass) {
+                $dependencies[$descriptor->position] = $request;
                 continue;
             }
 
-            if (!$request->has_param($parameter->getName())) {
+            if (!$request->has_param($descriptor->name)) {
                 continue;
             }
 
-            $value = $request->get_param($parameter->getName());
-            $value = $this->castRequestArgument($type, $value);
-            $dependencies[$parameter->getPosition()] = $value;
+            $value = $request->get_param($descriptor->name);
+            $dependencies[$descriptor->position] = $this->castRequestArgument($descriptor->typeName, $value);
         }
 
         return $dependencies;
     }
 
     /**
-     * @param \ReflectionNamedType $type
+     * @param string $typeName
      * @param mixed $value
      * @return mixed
      */
-    protected function castRequestArgument(\ReflectionNamedType $type, mixed $value): mixed
+    protected function castRequestArgument(string $typeName, mixed $value): mixed
     {
         if ($value === null) {
             return null;
         }
 
-        return match ($type->getName()) {
+        return match ($typeName) {
             'int' => (int)$value,
             'string' => (string)$value,
             default => $value,

--- a/tests/Unit/Wrappers/ReflectionCacheTest.php
+++ b/tests/Unit/Wrappers/ReflectionCacheTest.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpRestApi\Tests\Unit\Wrappers;
+
+use Dbout\WpRestApi\Tests\Unit\fixtures\AlwaysAllowPermission;
+use Dbout\WpRestApi\Tests\Unit\fixtures\PermissionCallbacks;
+use Dbout\WpRestApi\Tests\Unit\fixtures\RouteWithFatalError;
+use Dbout\WpRestApi\Wrappers\ParameterDescriptor;
+use Dbout\WpRestApi\Wrappers\ReflectionCache;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Dbout\WpRestApi\Wrappers\ReflectionCache
+ */
+class ReflectionCacheTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        ReflectionCache::clear();
+    }
+
+    /**
+     * @covers ::parameters
+     */
+    public function testParametersReturnsDescriptors(): void
+    {
+        $descriptors = ReflectionCache::parameters(PermissionCallbacks::class, 'allow');
+
+        $this->assertCount(1, $descriptors);
+        $this->assertInstanceOf(ParameterDescriptor::class, $descriptors[0]);
+        $this->assertSame('request', $descriptors[0]->name);
+        $this->assertSame(0, $descriptors[0]->position);
+        $this->assertSame(\WP_REST_Request::class, $descriptors[0]->typeName);
+    }
+
+    /**
+     * @covers ::parameters
+     */
+    public function testParametersAreMemoized(): void
+    {
+        $first = ReflectionCache::parameters(PermissionCallbacks::class, 'allow');
+        $second = ReflectionCache::parameters(PermissionCallbacks::class, 'allow');
+
+        // Identity check on the array AND on the descriptor instance proves
+        // the second call hit the cache and didn't rebuild anything.
+        $this->assertSame($first, $second);
+        $this->assertSame($first[0], $second[0]);
+    }
+
+    /**
+     * @covers ::parameters
+     */
+    public function testParametersOnMethodWithoutArgsReturnsEmptyArray(): void
+    {
+        $descriptors = ReflectionCache::parameters(RouteWithFatalError::class, 'execute');
+        $this->assertSame([], $descriptors);
+    }
+
+    /**
+     * @covers ::parameters
+     */
+    public function testParametersThrowsOnUnknownMethod(): void
+    {
+        $this->expectException(\ReflectionException::class);
+        ReflectionCache::parameters(PermissionCallbacks::class, 'doesNotExist');
+    }
+
+    /**
+     * @covers ::implementsPermissionInterface
+     */
+    public function testImplementsPermissionInterfaceTrue(): void
+    {
+        $this->assertTrue(ReflectionCache::implementsPermissionInterface(AlwaysAllowPermission::class));
+    }
+
+    /**
+     * @covers ::implementsPermissionInterface
+     */
+    public function testImplementsPermissionInterfaceFalse(): void
+    {
+        $this->assertFalse(ReflectionCache::implementsPermissionInterface(PermissionCallbacks::class));
+    }
+
+    /**
+     * @covers ::implementsPermissionInterface
+     * @covers ::clear
+     */
+    public function testImplementsPermissionInterfaceIsMemoized(): void
+    {
+        // Prime the cache.
+        $this->assertTrue(ReflectionCache::implementsPermissionInterface(AlwaysAllowPermission::class));
+
+        // Second call must hit the in-memory cache; no easy way to spy on
+        // ReflectionClass construction, so we settle for behavioural parity.
+        $this->assertTrue(ReflectionCache::implementsPermissionInterface(AlwaysAllowPermission::class));
+
+        // After clear(), the cache is rebuilt — still returning the right answer.
+        ReflectionCache::clear();
+        $this->assertTrue(ReflectionCache::implementsPermissionInterface(AlwaysAllowPermission::class));
+    }
+}


### PR DESCRIPTION
### Summary

  Memoize the reflection metadata used by `RestWrapper` and `PermissionWrapper` so that route handlers and permission classes are no longer re-reflected on every request.

  ### Why
  
  Both wrappers built a fresh `ReflectionClass` (and, for `RestWrapper`, a `ReflectionMethod` plus the entire parameter list with `getParameters()` / `getType()`) on **every** HTTP request. Class metadata is constant for a
  worker's lifetime — the wasted allocation is pure overhead for high-traffic endpoints.

### What changed

  - `src/Wrappers/ReflectionCache.php` (new) — process-local static memoization for parameter descriptors and the `implementsInterface(PermissionInterface)` lookup, plus a `clear()` for tests.
  - `src/Wrappers/ParameterDescriptor.php` (new) — small readonly value object holding `name`, `position`, and `typeName`. Replaces `\ReflectionParameter` at the call site.
  - `src/Wrappers/RestWrapper.php` — `execute()` no longer instantiates `\ReflectionClass` / `\ReflectionMethod`. Handlers run as `(new $class)->{$method}(...$deps)`. `collectDependencies()` reads cached descriptors instead of
  re-reflecting.
  - `src/Wrappers/PermissionWrapper.php` — `\ReflectionClass` swapped for the cached interface check; `$ref->newInstance()` swapped for `new $permissionCallback()`.