### PR TITLE
 ✨ Support RFC 7807 error responses and harden debug mode

### DIFF
--- a/src/ErrorFormat/DefaultFormatter.php
+++ b/src/ErrorFormat/DefaultFormatter.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpRestApi\ErrorFormat;
+
+use Dbout\WpRestApi\Exceptions\RouteException;
+
+final class DefaultFormatter implements ErrorFormatterInterface
+{
+    public const DEFAULT_ERROR_CODE = 'route-exception';
+
+    /**
+     * @inheritDoc
+     */
+    public function format(RouteException $exception, bool $debug): array
+    {
+        return [
+            'error' => [
+                'code' => $exception->getErrorCode() ?? self::DEFAULT_ERROR_CODE,
+                'message' => $exception->getMessage(),
+                'data' => $exception->getAdditionalData(),
+            ],
+        ];
+    }
+
+    public function contentType(): ?string
+    {
+        return null;
+    }
+}

--- a/src/ErrorFormat/ErrorFormatterInterface.php
+++ b/src/ErrorFormat/ErrorFormatterInterface.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpRestApi\ErrorFormat;
+
+use Dbout\WpRestApi\Exceptions\RouteException;
+
+interface ErrorFormatterInterface
+{
+    /**
+     * Build the response body for the given exception.
+     *
+     * @param RouteException $exception
+     * @param bool $debug
+     * @return array<string, mixed>
+     */
+    public function format(RouteException $exception, bool $debug): array;
+
+    /**
+     * Return the Content-Type header to set on the error response,
+     * or null to leave the default JSON Content-Type unchanged.
+     */
+    public function contentType(): ?string;
+}

--- a/src/ErrorFormat/ProblemJsonFormatter.php
+++ b/src/ErrorFormat/ProblemJsonFormatter.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpRestApi\ErrorFormat;
+
+use Dbout\WpRestApi\Exceptions\RouteException;
+
+/**
+ * RFC 7807 (application/problem+json) error formatter.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc7807
+ */
+final class ProblemJsonFormatter implements ErrorFormatterInterface
+{
+    public const CONTENT_TYPE = 'application/problem+json';
+    public const DEFAULT_TITLE = 'route-exception';
+
+    /**
+     * @inheritDoc
+     */
+    public function format(RouteException $exception, bool $debug): array
+    {
+        $body = [
+            'type' => 'about:blank',
+            'title' => $exception->getErrorCode() ?? self::DEFAULT_TITLE,
+            'status' => $exception->getHttpStatusCode(),
+            'detail' => $exception->getMessage(),
+        ];
+
+        $data = $exception->getAdditionalData();
+        if ($data !== []) {
+            $body['data'] = $data;
+        }
+
+        return $body;
+    }
+
+    public function contentType(): string
+    {
+        return self::CONTENT_TYPE;
+    }
+}

--- a/src/RouteLoader.php
+++ b/src/RouteLoader.php
@@ -8,6 +8,7 @@
 
 namespace Dbout\WpRestApi;
 
+use Dbout\WpRestApi\ErrorFormat\DefaultFormatter;
 use Dbout\WpRestApi\Exceptions\ApiException;
 use Dbout\WpRestApi\Helpers\FileLocator;
 use Dbout\WpRestApi\Loaders\AnnotationDirectoryLoader;
@@ -270,15 +271,18 @@ class RouteLoader
     protected function buildRouteArgs(Route $route): array
     {
         $actions = [];
-        $isDebug = $this->options?->debug;
-        if ($isDebug === null) {
-            $isDebug = false;
-        }
+        $options = $this->options ?? new RouteLoaderOptions();
+        $isDebug = $options->debug;
+        $errorFormatter = $options->errorFormatter ?? new DefaultFormatter();
 
         foreach ($route->actions as $action) {
             $actions[] = [
                 'methods' => $action->methods,
-                'callback' => [new RestWrapper($action, $isDebug), 'execute'],
+                'callback' => [new RestWrapper(
+                    $action,
+                    $isDebug,
+                    $errorFormatter,
+                ), 'execute'],
                 'permission_callback' => [new PermissionWrapper($action), 'execute'],
                 'args' => [],
             ];

--- a/src/RouteLoaderOptions.php
+++ b/src/RouteLoaderOptions.php
@@ -8,6 +8,7 @@
 
 namespace Dbout\WpRestApi;
 
+use Dbout\WpRestApi\ErrorFormat\ErrorFormatterInterface;
 use Psr\Cache\CacheItemPoolInterface;
 
 class RouteLoaderOptions
@@ -17,12 +18,18 @@ class RouteLoaderOptions
     /**
      * @param CacheItemPoolInterface|null $cache
      * @param string $cacheKey
-     * @param bool $debug
+     * @param bool $debug MUST NOT be enabled in production: forwards the raw
+     *                    message of non-RouteException errors and, when
+     *                    WP_DEBUG is also true, attaches the stack trace.
+     * @param ErrorFormatterInterface|null $errorFormatter Optional pluggable
+     *                    error response shape. Defaults to the historical
+     *                    {error: {code, message, data}} envelope.
      */
     public function __construct(
         public ?CacheItemPoolInterface $cache = null,
         public string $cacheKey = self::DEFAULT_CACHE_KEY,
         public bool $debug = false,
+        public ?ErrorFormatterInterface $errorFormatter = null,
     ) {
     }
 }

--- a/src/Wrappers/RestWrapper.php
+++ b/src/Wrappers/RestWrapper.php
@@ -8,6 +8,8 @@
 
 namespace Dbout\WpRestApi\Wrappers;
 
+use Dbout\WpRestApi\ErrorFormat\DefaultFormatter;
+use Dbout\WpRestApi\ErrorFormat\ErrorFormatterInterface;
 use Dbout\WpRestApi\Exceptions\RouteException;
 use Dbout\WpRestApi\RouteAction;
 
@@ -15,14 +17,17 @@ class RestWrapper
 {
     private const DEFAULT_EXCEPTION_CODE = 'route-exception';
     private const DEFAULT_EXCEPTION_HTTP_CODE = 500;
+    private const REDACTED_MESSAGE = 'Something went wrong. Please try again.';
 
     /**
      * @param RouteAction $action
      * @param bool $debug
+     * @param ErrorFormatterInterface $errorFormatter
      */
     public function __construct(
         protected RouteAction $action,
         protected bool $debug = false,
+        protected ErrorFormatterInterface $errorFormatter = new DefaultFormatter(),
     ) {
     }
 
@@ -43,10 +48,7 @@ class RestWrapper
         }
 
         if (is_wp_error($response)) {
-            return $this->parseErrorToRestResponse(
-                $response,
-                self::DEFAULT_EXCEPTION_HTTP_CODE
-            );
+            return $this->onWpError($response);
         }
 
         return $response;
@@ -61,28 +63,53 @@ class RestWrapper
         $rootException = $exception;
         if (!$exception instanceof RouteException) {
             $exception = new RouteException(
-                message: 'Something went wrong. Please try again.',
+                message: $this->debug === true ? $rootException->getMessage() : self::REDACTED_MESSAGE,
                 errorCode: 'fatal-error',
                 httpStatusCode: self::DEFAULT_EXCEPTION_HTTP_CODE,
             );
         }
 
-        if ($this->debug === true) {
-            $exception = new RouteException(
-                message: $rootException->getMessage(),
-                errorCode: $exception->getErrorCode(),
-                httpStatusCode: $exception->getHttpStatusCode(),
-                additionalData: array_merge($exception->getAdditionalData(), [
-                    'exception' => $rootException->getTraceAsString(),
-                ]),
-                previous: $rootException,
-            );
+        $additionalData = $exception->getAdditionalData();
+        if ($this->debug === true && $this->isWpDebugEnabled()) {
+            $additionalData['exception'] = $rootException->getTraceAsString();
         }
 
-        return $this->parseErrorToRestResponse(
-            $this->buildResponseError($exception),
-            $exception->getHttpStatusCode()
+        $exception = new RouteException(
+            message: $exception->getMessage(),
+            errorCode: $exception->getErrorCode(),
+            httpStatusCode: $exception->getHttpStatusCode(),
+            additionalData: $additionalData,
+            previous: $rootException,
         );
+
+        return $this->buildErrorResponse($exception);
+    }
+
+    /**
+     * @param \WP_Error $error
+     * @return \WP_REST_Response
+     */
+    protected function onWpError(\WP_Error $error): \WP_REST_Response
+    {
+        $code = null;
+        $message = '';
+        $data = [];
+        foreach ((array) $error->errors as $errorCode => $messages) {
+            $code = (string) $errorCode;
+            $message = (string) ($messages[0] ?? '');
+            $rawData = $error->get_error_data($errorCode);
+            $data = is_array($rawData) ? $rawData : [];
+            break;
+        }
+
+        $exception = new RouteException(
+            message: $message,
+            errorCode: $code ?? self::DEFAULT_EXCEPTION_CODE,
+            httpStatusCode: self::DEFAULT_EXCEPTION_HTTP_CODE,
+            additionalData: $data,
+        );
+
+        return $this->buildErrorResponse($exception);
     }
 
     /**
@@ -137,44 +164,30 @@ class RestWrapper
     }
 
     /**
-     * @param RouteException $exception
-     * @return \WP_Error
+     * Defense in depth: stack traces are only ever included when both the
+     * RouteLoaderOptions::$debug flag and the WP_DEBUG constant are true.
+     * Exposed as a protected method so tests can simulate WP_DEBUG=false
+     * without having to redefine a PHP constant.
      */
-    protected function buildResponseError(
-        RouteException $exception,
-    ): \WP_Error {
-        return new \WP_Error(
-            $exception->getErrorCode() ?? self::DEFAULT_EXCEPTION_CODE,
-            $exception->getMessage(),
-            $exception->getAdditionalData()
-        );
+    protected function isWpDebugEnabled(): bool
+    {
+        return defined('WP_DEBUG') && WP_DEBUG === true;
     }
 
     /**
-     * @param \WP_Error $error
-     * @param int $httpCode
+     * @param RouteException $exception
      * @return \WP_REST_Response
      */
-    protected function parseErrorToRestResponse(\WP_Error $error, int $httpCode): \WP_REST_Response
+    protected function buildErrorResponse(RouteException $exception): \WP_REST_Response
     {
-        $errors = [];
-        foreach ((array) $error->errors as $code => $messages) {
-            foreach ((array) $messages as $message) {
-                $errors[] = [
-                    'code' => $code,
-                    'message' => $message,
-                    'data' => $error->get_error_data($code),
-                ];
-            }
+        $body = $this->errorFormatter->format($exception, $this->debug);
+        $response = new \WP_REST_Response($body, $exception->getHttpStatusCode());
+
+        $contentType = $this->errorFormatter->contentType();
+        if ($contentType !== null) {
+            $response->header('Content-Type', $contentType);
         }
 
-        $data = array_shift($errors);
-        if ($errors !== []) {
-            $data['additional_errors'] = $errors;
-        }
-
-        return new \WP_REST_Response([
-            'error' => $data,
-        ], $httpCode);
+        return $response;
     }
 }

--- a/tests/Unit/Bootstrap.php
+++ b/tests/Unit/Bootstrap.php
@@ -39,7 +39,10 @@ class Bootstrap
     protected function initConstants(): void
     {
         define('ABSPATH', sprintf('%s/', $this->wpDirectory));
-        define('WP_DEBUG', false);
+        // Enabled so the RestWrapper debug-mode tests can exercise the
+        // WP_DEBUG + RouteLoaderOptions::$debug AND-gate. Individual tests
+        // can stub isWpDebugEnabled() to simulate WP_DEBUG=false.
+        define('WP_DEBUG', true);
         define('WP_CONTENT_DIR', '/');
         define('WP_DEBUG_LOG', false);
         define('WP_PLUGIN_DIR', './');

--- a/tests/Unit/ErrorFormat/DefaultFormatterTest.php
+++ b/tests/Unit/ErrorFormat/DefaultFormatterTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpRestApi\Tests\Unit\ErrorFormat;
+
+use Dbout\WpRestApi\ErrorFormat\DefaultFormatter;
+use Dbout\WpRestApi\Exceptions\RouteException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Dbout\WpRestApi\ErrorFormat\DefaultFormatter
+ */
+class DefaultFormatterTest extends TestCase
+{
+    /**
+     * @covers ::format
+     * @covers ::contentType
+     */
+    public function testHistoricalShapeIsPreserved(): void
+    {
+        $formatter = new DefaultFormatter();
+
+        $exception = new RouteException(
+            message: 'Object not found.',
+            errorCode: 'not-found',
+            httpStatusCode: 404,
+            additionalData: ['hint' => 'check the id'],
+        );
+
+        $this->assertSame([
+            'error' => [
+                'code' => 'not-found',
+                'message' => 'Object not found.',
+                'data' => ['hint' => 'check the id'],
+            ],
+        ], $formatter->format($exception, false));
+
+        $this->assertNull($formatter->contentType(), 'Default formatter must not override Content-Type.');
+    }
+
+    /**
+     * @covers ::format
+     */
+    public function testCodeFallsBackWhenErrorCodeIsNull(): void
+    {
+        $body = (new DefaultFormatter())->format(
+            new RouteException(message: 'Boom', errorCode: null, httpStatusCode: 500),
+            false,
+        );
+
+        $this->assertSame(DefaultFormatter::DEFAULT_ERROR_CODE, $body['error']['code']);
+    }
+}

--- a/tests/Unit/ErrorFormat/ProblemJsonFormatterTest.php
+++ b/tests/Unit/ErrorFormat/ProblemJsonFormatterTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpRestApi\Tests\Unit\ErrorFormat;
+
+use Dbout\WpRestApi\ErrorFormat\ProblemJsonFormatter;
+use Dbout\WpRestApi\Exceptions\RouteException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Dbout\WpRestApi\ErrorFormat\ProblemJsonFormatter
+ */
+class ProblemJsonFormatterTest extends TestCase
+{
+    /**
+     * @covers ::format
+     * @covers ::contentType
+     */
+    public function testShapeMatchesSpec(): void
+    {
+        $formatter = new ProblemJsonFormatter();
+
+        $exception = new RouteException(
+            message: 'Object not found.',
+            errorCode: 'not-found',
+            httpStatusCode: 404,
+        );
+
+        $body = $formatter->format($exception, false);
+
+        $this->assertSame([
+            'type' => 'about:blank',
+            'title' => 'not-found',
+            'status' => 404,
+            'detail' => 'Object not found.',
+        ], $body);
+
+        $this->assertSame('application/problem+json', $formatter->contentType());
+    }
+
+    /**
+     * @covers ::format
+     */
+    public function testAdditionalDataIsAppendedWhenPresent(): void
+    {
+        $formatter = new ProblemJsonFormatter();
+
+        $exception = new RouteException(
+            message: 'Validation failed.',
+            errorCode: 'invalid-payload',
+            httpStatusCode: 422,
+            additionalData: ['fields' => ['name' => 'required']],
+        );
+
+        $body = $formatter->format($exception, false);
+
+        $this->assertSame(['fields' => ['name' => 'required']], $body['data']);
+    }
+
+    /**
+     * @covers ::format
+     */
+    public function testEmptyAdditionalDataIsOmitted(): void
+    {
+        $body = (new ProblemJsonFormatter())->format(
+            new RouteException(message: 'Boom', errorCode: 'boom', httpStatusCode: 500),
+            false,
+        );
+
+        $this->assertArrayNotHasKey('data', $body, 'RFC 7807 body should not carry an empty "data" key.');
+    }
+
+    /**
+     * @covers ::format
+     */
+    public function testTitleFallsBackToDefaultWhenErrorCodeIsNull(): void
+    {
+        $body = (new ProblemJsonFormatter())->format(
+            new RouteException(message: 'Boom', errorCode: null, httpStatusCode: 500),
+            false,
+        );
+
+        $this->assertSame(ProblemJsonFormatter::DEFAULT_TITLE, $body['title']);
+    }
+}

--- a/tests/Unit/Wrappers/RestWrapperTest.php
+++ b/tests/Unit/Wrappers/RestWrapperTest.php
@@ -8,6 +8,7 @@
 
 namespace Dbout\WpRestApi\Tests\Unit\Wrappers;
 
+use Dbout\WpRestApi\ErrorFormat\ProblemJsonFormatter;
 use Dbout\WpRestApi\RouteAction;
 use Dbout\WpRestApi\Tests\Unit\fixtures\RouteReturningResponse;
 use Dbout\WpRestApi\Tests\Unit\fixtures\RouteReturningWpError;
@@ -191,6 +192,88 @@ class RestWrapperTest extends TestCase
         $this->assertSame('forbidden_action', $error['code']);
         $this->assertSame('You may not do this.', $error['message']);
         $this->assertSame(['details' => 'no'], $error['data']);
+    }
+
+    /**
+     * @covers ::onError
+     * @covers ::buildErrorResponse
+     */
+    public function testProblemJsonContentType(): void
+    {
+        $action = new RouteAction(RouteWithNotFoundException::class, 'execute', ['GET'], null);
+        $wrapper = new RestWrapper(
+            $action,
+            false,
+            new ProblemJsonFormatter(),
+        );
+
+        $response = $wrapper->execute(new \WP_REST_Request());
+
+        $this->assertSame(404, $response->get_status());
+        $this->assertSame(ProblemJsonFormatter::CONTENT_TYPE, $response->get_headers()['Content-Type'] ?? null);
+
+        $body = $response->get_data();
+        $this->assertSame('about:blank', $body['type']);
+        $this->assertSame('not-found', $body['title']);
+        $this->assertSame(404, $body['status']);
+        $this->assertSame('Object not found.', $body['detail']);
+        $this->assertArrayNotHasKey('error', $body, 'Problem+json body MUST NOT carry the legacy "error" envelope.');
+    }
+
+    /**
+     * @covers ::onError
+     * @covers ::isWpDebugEnabled
+     */
+    public function testDebugModeRequiresWpDebug(): void
+    {
+        $action = new RouteAction(RouteWithRouteException::class, 'execute', ['GET'], null);
+
+        // Subclass overrides isWpDebugEnabled() to simulate WP_DEBUG=false;
+        // the trace must NOT be exposed even though $debug is true.
+        $wrapper = new class ($action, true) extends RestWrapper {
+            protected function isWpDebugEnabled(): bool
+            {
+                return false;
+            }
+        };
+
+        $response = $wrapper->execute(new \WP_REST_Request());
+        $data = $response->get_data()['error']['data'] ?? [];
+        $this->assertArrayNotHasKey(
+            'exception',
+            $data,
+            'Stack trace MUST stay out of the response when WP_DEBUG is false, even with debug=true.'
+        );
+
+        // Sanity: with WP_DEBUG=true (bootstrap default) the trace IS attached.
+        $wrapperWithWpDebug = new RestWrapper($action, true);
+        $dataWithWpDebug = $wrapperWithWpDebug->execute(new \WP_REST_Request())->get_data()['error']['data'] ?? [];
+        $this->assertArrayHasKey('exception', $dataWithWpDebug);
+    }
+
+    /**
+     * @covers ::onError
+     */
+    public function testUnknownExceptionMessageIsRedactedByDefault(): void
+    {
+        $action = new RouteAction(RouteWithException::class, 'execute', ['GET'], null);
+
+        // Without debug mode: the original message must not leak.
+        $wrapper = new RestWrapper($action);
+        $error = $wrapper->execute(new \WP_REST_Request())->get_data()['error'] ?? [];
+
+        $this->assertSame('Something went wrong. Please try again.', $error['message']);
+        $this->assertStringNotContainsString(
+            'My custom exception.',
+            json_encode($error) ?: '',
+            'Original exception message must not leak anywhere in the response when debug=false.'
+        );
+
+        // Debug mode: the raw message comes through.
+        $debugError = (new RestWrapper($action, true))
+            ->execute(new \WP_REST_Request())
+            ->get_data()['error'] ?? [];
+        $this->assertSame('My custom exception.', $debugError['message']);
     }
 
     /**

--- a/tests/WordPress/RouteLoaderIntegrationTest.php
+++ b/tests/WordPress/RouteLoaderIntegrationTest.php
@@ -8,7 +8,9 @@
 
 namespace Dbout\WpRestApi\Tests\WordPress;
 
+use Dbout\WpRestApi\ErrorFormat\ProblemJsonFormatter;
 use Dbout\WpRestApi\RouteLoader;
+use Dbout\WpRestApi\RouteLoaderOptions;
 
 class RouteLoaderIntegrationTest extends \WP_UnitTestCase
 {
@@ -86,5 +88,28 @@ class RouteLoaderIntegrationTest extends \WP_UnitTestCase
         $error = $response->get_data()['error'] ?? null;
         $this->assertSame('not-found', $error['code']);
         $this->assertSame('Resource not found.', $error['message']);
+    }
+
+    public function testProblemJsonFormatterIsUsedWhenConfigured(): void
+    {
+        $options = new RouteLoaderOptions(errorFormatter: new ProblemJsonFormatter());
+        (new RouteLoader(self::FIXTURES_DIR . '/ProblemJsonRoute', $options))->register();
+        do_action('rest_api_init');
+
+        $response = rest_do_request(new \WP_REST_Request('GET', '/integration/v1/problem'));
+
+        $this->assertSame(404, $response->get_status());
+        $this->assertSame(
+            ProblemJsonFormatter::CONTENT_TYPE,
+            $response->get_headers()['Content-Type'] ?? null,
+            'application/problem+json header MUST be set when ProblemJsonFormatter is used.'
+        );
+
+        $body = $response->get_data();
+        $this->assertSame('about:blank', $body['type']);
+        $this->assertSame('not-found', $body['title']);
+        $this->assertSame(404, $body['status']);
+        $this->assertSame('Problem not found.', $body['detail']);
+        $this->assertArrayNotHasKey('error', $body);
     }
 }

--- a/tests/WordPress/fixtures/ProblemJsonRoute/ProblemJsonRoute.php
+++ b/tests/WordPress/fixtures/ProblemJsonRoute/ProblemJsonRoute.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpRestApi\Tests\WordPress\fixtures\ProblemJsonRoute;
+
+use Dbout\WpRestApi\Attributes\Action;
+use Dbout\WpRestApi\Attributes\Route;
+use Dbout\WpRestApi\Enums\Method;
+use Dbout\WpRestApi\Exceptions\NotFoundException;
+
+#[Route('integration/v1', '/problem')]
+class ProblemJsonRoute
+{
+    #[Action(Method::GET)]
+    public function get(): never
+    {
+        throw new NotFoundException('Problem');
+    }
+}


### PR DESCRIPTION
- Add `ErrorFormatterInterface` with `DefaultForm`atter (legacy shape) and `ProblemJsonFormatter` (sets application/problem+json header)
- Wire formatter through `RouteLoaderOptions::$errorFormatter
`- Gate stack traces behind debug=true AND WP_DEBUG=true (defense in depth)
- Redact non-RouteException messages when debug=false
- Cover with unit tests (ProblemJsonFormatter, DefaultFormatter,  RestWrapper) and an integration test asserting the Content-Type header end-to-end