### PR TITLE
✨ Compile WP args schema from #[Param] attribute on handler parameters

### DIFF
--- a/src/Attributes/Param.php
+++ b/src/Attributes/Param.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpRestApi\Attributes;
+
+/**
+ * Describes the WP REST argument schema for a single handler parameter.
+ * Compiled into the `args` array of register_rest_route by the loader,
+ * letting WordPress enforce required/type/enum/sanitize before the
+ * handler runs.
+ *
+ * @see https://developer.wordpress.org/rest-api/extending-the-rest-api/adding-custom-endpoints/#arguments
+ */
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+class Param
+{
+    /**
+     * @param string|null $name Request key. Defaults to the PHP parameter name.
+     * @param string|null $type WP type ('string', 'integer', 'number', 'boolean',
+     *                          'array', 'object'). Inferred from the PHP type when null.
+     * @param bool $required
+     * @param mixed $default
+     * @param mixed[]|null $enum Allowed values; auto-populated from a BackedEnum.
+     * @param string|null $description
+     * @param mixed $sanitizeCallback Cacheable callable (string or [class, method]).
+     * @param mixed $validateCallback Cacheable callable (string or [class, method]).
+     */
+    public function __construct(
+        public readonly ?string $name = null,
+        public readonly ?string $type = null,
+        public readonly bool $required = false,
+        public readonly mixed $default = null,
+        public readonly ?array $enum = null,
+        public readonly ?string $description = null,
+        public readonly mixed $sanitizeCallback = null,
+        public readonly mixed $validateCallback = null,
+    ) {
+    }
+}

--- a/src/Loaders/AnnotatedRouteRestLoader.php
+++ b/src/Loaders/AnnotatedRouteRestLoader.php
@@ -9,8 +9,10 @@
 namespace Dbout\WpRestApi\Loaders;
 
 use Dbout\WpRestApi\Attributes\Action;
+use Dbout\WpRestApi\Attributes\Param;
 use Dbout\WpRestApi\Attributes\Route;
 use Dbout\WpRestApi\Enums\Method;
+use Dbout\WpRestApi\ParamSpec;
 use Dbout\WpRestApi\Route as RestRoute;
 use Dbout\WpRestApi\RouteAction;
 
@@ -97,7 +99,140 @@ class AnnotatedRouteRestLoader implements InterfaceLoader
             $reflectionClass->getName(),
             $method->getName(),
             $methods,
-            $action->permissionCallback ?? $route->permissionCallback
+            $action->permissionCallback ?? $route->permissionCallback,
+            $this->collectParams($method),
         );
+    }
+
+    /**
+     * @param \ReflectionMethod $method
+     * @return array<ParamSpec>
+     */
+    protected function collectParams(\ReflectionMethod $method): array
+    {
+        $params = [];
+        foreach ($method->getParameters() as $parameter) {
+            $attribute = $parameter->getAttributes(Param::class)[0] ?? null;
+            if ($attribute === null) {
+                continue;
+            }
+
+            /** @var Param $param */
+            $param = $attribute->newInstance();
+            $params[] = $this->compileParam($parameter, $param);
+        }
+
+        return $params;
+    }
+
+    /**
+     * Translate a single Param attribute (+ the PHP type) into the WP args shape.
+     */
+    protected function compileParam(\ReflectionParameter $parameter, Param $param): ParamSpec
+    {
+        $phpName = $parameter->getName();
+        $requestName = $param->name ?? $phpName;
+
+        $reflectionType = $parameter->getType();
+        $phpType = $reflectionType instanceof \ReflectionNamedType ? $reflectionType->getName() : null;
+        $nullable = $reflectionType instanceof \ReflectionNamedType && $reflectionType->allowsNull();
+
+        $args = [];
+
+        $type = $param->type ?? $this->inferWpType($phpType);
+        if ($type !== null) {
+            $args['type'] = $nullable ? [$type, 'null'] : $type;
+        }
+
+        if ($param->required) {
+            $args['required'] = true;
+        }
+
+        if ($param->default !== null) {
+            $args['default'] = $param->default;
+        } elseif ($parameter->isDefaultValueAvailable() && !$param->required) {
+            $args['default'] = $parameter->getDefaultValue();
+        }
+
+        $enum = $param->enum ?? $this->inferEnumFromBackedEnum($phpType);
+        if ($enum !== null) {
+            $args['enum'] = $enum;
+        }
+
+        if ($param->description !== null) {
+            $args['description'] = $param->description;
+        }
+
+        $sanitize = $param->sanitizeCallback ?? $this->inferSanitizeCallback($phpType);
+        if ($sanitize !== null) {
+            $args['sanitize_callback'] = $sanitize;
+        }
+
+        if ($param->validateCallback !== null) {
+            $args['validate_callback'] = $param->validateCallback;
+        }
+
+        return new ParamSpec($phpName, $requestName, $args);
+    }
+
+    /**
+     * @param string|null $phpType
+     * @return string|null
+     * @throws \ReflectionException
+     */
+    protected function inferWpType(?string $phpType): ?string
+    {
+        if ($phpType === null) {
+            return null;
+        }
+
+        if (is_subclass_of($phpType, \BackedEnum::class)) {
+            $reflectionEnum = new \ReflectionEnum($phpType);
+            $backing = $reflectionEnum->getBackingType();
+            return $backing instanceof \ReflectionNamedType && $backing->getName() === 'int'
+                ? 'integer'
+                : 'string';
+        }
+
+        return match ($phpType) {
+            'int' => 'integer',
+            'float' => 'number',
+            'bool' => 'boolean',
+            'string' => 'string',
+            'array' => 'array',
+            default => null,
+        };
+    }
+
+    /**
+     * @param string|null $phpType
+     * @return array<int|string>|null
+     */
+    protected function inferEnumFromBackedEnum(?string $phpType): ?array
+    {
+        if ($phpType === null || !is_subclass_of($phpType, \BackedEnum::class)) {
+            return null;
+        }
+
+        $values = [];
+        foreach ($phpType::cases() as $case) {
+            $values[] = $case->value;
+        }
+
+        return $values;
+    }
+
+    /**
+     * @param string|null $phpType
+     * @return string|null
+     */
+    protected function inferSanitizeCallback(?string $phpType): ?string
+    {
+        return match ($phpType) {
+            'int' => 'absint',
+            'string' => 'sanitize_text_field',
+            'bool' => 'rest_sanitize_boolean',
+            default => null,
+        };
     }
 }

--- a/src/Loaders/AnnotatedRouteRestLoader.php
+++ b/src/Loaders/AnnotatedRouteRestLoader.php
@@ -177,8 +177,8 @@ class AnnotatedRouteRestLoader implements InterfaceLoader
 
     /**
      * @param string|null $phpType
-     * @return string|null
      * @throws \ReflectionException
+     * @return string|null
      */
     protected function inferWpType(?string $phpType): ?string
     {

--- a/src/ParamSpec.php
+++ b/src/ParamSpec.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpRestApi;
+
+/**
+ * Pre-compiled WP REST argument descriptor for a single handler parameter.
+ * Built once at discovery time from a {@see \Dbout\WpRestApi\Attributes\Param}
+ * attribute (plus PHP type inference) and serialized into the route cache.
+ */
+final class ParamSpec
+{
+    /**
+     * @param string $phpName Name of the PHP parameter on the handler method.
+     *                        Used by the wrapper to inject the value.
+     * @param string $requestName Request key clients send. Defaults to $phpName
+     *                            unless Param::$name was supplied.
+     * @param array<string, mixed> $args Final WP `args` entry (the value that
+     *                            ships to register_rest_route under the
+     *                            $requestName key).
+     */
+    public function __construct(
+        public readonly string $phpName,
+        public readonly string $requestName,
+        public readonly array $args,
+    ) {
+    }
+}

--- a/src/RouteAction.php
+++ b/src/RouteAction.php
@@ -15,12 +15,15 @@ class RouteAction
      * @param string $methodName
      * @param array<string> $methods
      * @param mixed $permissionCallback
+     * @param array<ParamSpec> $params Compiled WP argument schema. Empty when
+     *                                 the handler declares no #[Param] attribute.
      */
     public function __construct(
         public readonly mixed $className,
         public readonly string $methodName,
         public readonly array $methods,
         public readonly mixed $permissionCallback,
+        public readonly array $params = [],
     ) {
     }
 }

--- a/src/RouteLoader.php
+++ b/src/RouteLoader.php
@@ -99,11 +99,17 @@ class RouteLoader
                     return null;
                 }
 
+                $params = $this->hydrateParams($rawAction['params'] ?? []);
+                if ($params === null) {
+                    return null;
+                }
+
                 $actions[] = new RouteAction(
                     $className,
                     $methodName,
                     array_values(array_filter($methods, is_string(...))),
                     $rawAction['permissionCallback'] ?? null,
+                    $params,
                 );
             }
 
@@ -135,11 +141,23 @@ class RouteLoader
                     return null;
                 }
 
+                $serializedParams = $this->dehydrateParams($action->params);
+                if ($serializedParams === null) {
+                    trigger_error(sprintf(
+                        'Route %s/%s has a Param callback that cannot be cached (Closure or non-serializable value); the route cache will be skipped.',
+                        $route->namespace,
+                        $route->path,
+                    ), \E_USER_NOTICE);
+
+                    return null;
+                }
+
                 $actions[] = [
                     'className' => $action->className,
                     'methodName' => $action->methodName,
                     'methods' => $action->methods,
                     'permissionCallback' => $action->permissionCallback,
+                    'params' => $serializedParams,
                 ];
             }
 
@@ -155,6 +173,64 @@ class RouteLoader
         } catch (\JsonException) {
             return null;
         }
+    }
+
+    /**
+     * @param mixed $raw Raw payload from the cache; not yet validated.
+     * @return array<ParamSpec>|null Null when the payload shape is invalid.
+     */
+    protected function hydrateParams(mixed $raw): ?array
+    {
+        if (!is_array($raw)) {
+            return null;
+        }
+
+        $params = [];
+        foreach ($raw as $entry) {
+            if (!is_array($entry)) {
+                return null;
+            }
+
+            $phpName = $entry['phpName'] ?? null;
+            $requestName = $entry['requestName'] ?? null;
+            $args = $entry['args'] ?? null;
+            if (!is_string($phpName) || !is_string($requestName) || !is_array($args)) {
+                return null;
+            }
+
+            $params[] = new ParamSpec($phpName, $requestName, $args);
+        }
+
+        return $params;
+    }
+
+    /**
+     * @param array<ParamSpec> $params
+     * @return array<int, array<string, mixed>>|null Null when at least one
+     *         param has a sanitize/validate callback that cannot be cached.
+     */
+    protected function dehydrateParams(array $params): ?array
+    {
+        $out = [];
+        foreach ($params as $spec) {
+            foreach (['sanitize_callback', 'validate_callback'] as $key) {
+                if (!array_key_exists($key, $spec->args)) {
+                    continue;
+                }
+
+                if (!$this->isCacheableCallback($spec->args[$key])) {
+                    return null;
+                }
+            }
+
+            $out[] = [
+                'phpName' => $spec->phpName,
+                'requestName' => $spec->requestName,
+                'args' => $spec->args,
+            ];
+        }
+
+        return $out;
     }
 
     /**
@@ -284,10 +360,24 @@ class RouteLoader
                     $errorFormatter,
                 ), 'execute'],
                 'permission_callback' => [new PermissionWrapper($action), 'execute'],
-                'args' => [],
+                'args' => $this->compileArgs($action),
             ];
         }
 
         return $actions;
+    }
+
+    /**
+     * @param RouteAction $action
+     * @return array<string, array<string, mixed>>
+     */
+    protected function compileArgs(RouteAction $action): array
+    {
+        $args = [];
+        foreach ($action->params as $spec) {
+            $args[$spec->requestName] = $spec->args;
+        }
+
+        return $args;
     }
 }

--- a/src/Wrappers/ParameterDescriptor.php
+++ b/src/Wrappers/ParameterDescriptor.php
@@ -16,13 +16,16 @@ namespace Dbout\WpRestApi\Wrappers;
 final class ParameterDescriptor
 {
     /**
-     * @param string $name Declared parameter name (used to look up request params).
+     * @param string $name Declared PHP parameter name.
+     * @param string $requestName Key clients send on the request; defaults to
+     *                            the PHP name unless overridden by #[Param(name: …)].
      * @param int $position Zero-based parameter position in the method signature.
      * @param string|null $typeName FQCN or scalar type name; null when the parameter
      *                              has no type or a non-named type (intersection / union).
      */
     public function __construct(
         public readonly string $name,
+        public readonly string $requestName,
         public readonly int $position,
         public readonly ?string $typeName,
     ) {

--- a/src/Wrappers/ReflectionCache.php
+++ b/src/Wrappers/ReflectionCache.php
@@ -8,6 +8,7 @@
 
 namespace Dbout\WpRestApi\Wrappers;
 
+use Dbout\WpRestApi\Attributes\Param;
 use Dbout\WpRestApi\Permissions\PermissionInterface;
 
 /**
@@ -41,8 +42,13 @@ final class ReflectionCache
         $descriptors = [];
         foreach ($reflection->getParameters() as $parameter) {
             $type = $parameter->getType();
+            $paramAttribute = $parameter->getAttributes(Param::class)[0] ?? null;
+            $paramInstance = $paramAttribute?->newInstance();
             $descriptors[] = new ParameterDescriptor(
                 name: $parameter->getName(),
+                requestName: $paramInstance instanceof Param && $paramInstance->name !== null
+                    ? $paramInstance->name
+                    : $parameter->getName(),
                 position: $parameter->getPosition(),
                 typeName: $type instanceof \ReflectionNamedType ? $type->getName() : null,
             );

--- a/src/Wrappers/RestWrapper.php
+++ b/src/Wrappers/RestWrapper.php
@@ -134,11 +134,11 @@ class RestWrapper
                 continue;
             }
 
-            if (!$request->has_param($descriptor->name)) {
+            if (!$request->has_param($descriptor->requestName)) {
                 continue;
             }
 
-            $value = $request->get_param($descriptor->name);
+            $value = $request->get_param($descriptor->requestName);
             $dependencies[$descriptor->position] = $this->castRequestArgument($descriptor->typeName, $value);
         }
 
@@ -156,9 +156,15 @@ class RestWrapper
             return null;
         }
 
+        if (is_subclass_of($typeName, \BackedEnum::class)) {
+            return $typeName::from($value);
+        }
+
         return match ($typeName) {
             'int' => (int)$value,
             'string' => (string)$value,
+            'float' => (float)$value,
+            'bool' => (bool)$value,
             default => $value,
         };
     }

--- a/tests/Unit/RouteLoaderTest.php
+++ b/tests/Unit/RouteLoaderTest.php
@@ -152,6 +152,106 @@ class RouteLoaderTest extends TestCase
     }
 
     /**
+     * @covers ::buildRouteArgs
+     * @covers ::compileArgs
+     */
+    public function testBuildRouteArgsCompilesSchema(): void
+    {
+        $loader = new RouteLoader(__DIR__ . '/fixtures/Loaders/WithParams');
+        $routes = $this->invokeGetRoutes($loader);
+
+        $this->assertCount(1, $routes);
+        $args = $this->invokeBuildRouteArgs($loader, $routes[0]);
+        $this->assertCount(1, $args, 'WithParams fixture exposes a single action.');
+
+        $compiled = $args[0]['args'];
+        $this->assertArrayHasKey('id', $compiled);
+        $this->assertArrayHasKey('perPage', $compiled);
+        $this->assertArrayHasKey('q', $compiled, 'The request key MUST be Param::$name when overridden.');
+
+        $this->assertTrue($compiled['id']['required']);
+        $this->assertSame('integer', $compiled['id']['type']);
+        $this->assertSame('absint', $compiled['id']['sanitize_callback']);
+        $this->assertSame('Item identifier', $compiled['id']['description']);
+
+        $this->assertSame(10, $compiled['perPage']['default']);
+
+        $this->assertSame('sanitize_text_field', $compiled['q']['sanitize_callback']);
+    }
+
+    /**
+     * @covers ::buildRouteArgs
+     * @covers ::compileArgs
+     */
+    public function testEnumParameterPopulatesEnumOption(): void
+    {
+        $loader = new RouteLoader(__DIR__ . '/fixtures/Loaders/WithEnumParam');
+        $routes = $this->invokeGetRoutes($loader);
+
+        $this->assertCount(1, $routes);
+        $args = $this->invokeBuildRouteArgs($loader, $routes[0]);
+
+        $directionArg = $args[0]['args']['direction'] ?? null;
+        $this->assertIsArray($directionArg);
+        $this->assertSame('string', $directionArg['type']);
+        $this->assertSame(['asc', 'desc'], $directionArg['enum']);
+    }
+
+    /**
+     * @covers ::buildRouteArgs
+     * @covers ::compileArgs
+     */
+    public function testHandlerWithoutParamAttributeRegistersEmptyArgs(): void
+    {
+        $loader = new RouteLoader(self::FIXTURE_DIR);
+        $routes = $this->invokeGetRoutes($loader);
+
+        $args = $this->invokeBuildRouteArgs($loader, $routes[0]);
+        $this->assertSame([], $args[0]['args'], 'Backward compat: handlers without #[Param] stay with empty args.');
+    }
+
+    /**
+     * @covers ::dehydrateRoutes
+     * @covers ::hydrateRoutes
+     * @covers ::dehydrateParams
+     * @covers ::hydrateParams
+     */
+    public function testParamSpecSurvivesCacheRoundtrip(): void
+    {
+        $cache = new ArrayCachePool();
+        $loader = new RouteLoader(
+            __DIR__ . '/fixtures/Loaders/WithParams',
+            new RouteLoaderOptions(cache: $cache),
+        );
+
+        $first = $this->invokeGetRoutes($loader);
+
+        // Second call hits the cache and rebuilds RouteAction::$params from JSON.
+        $bogus = new RouteLoader('/does/not/exist', new RouteLoaderOptions(cache: $cache));
+        $second = $this->invokeGetRoutes($bogus);
+
+        $this->assertSame(
+            $this->paramArgsByRequestName($first[0]->actions[0]->params),
+            $this->paramArgsByRequestName($second[0]->actions[0]->params),
+            'ParamSpec list must come back identical from the cache.',
+        );
+    }
+
+    /**
+     * @param array<\Dbout\WpRestApi\ParamSpec> $params
+     * @return array<string, array<string, mixed>>
+     */
+    private function paramArgsByRequestName(array $params): array
+    {
+        $out = [];
+        foreach ($params as $spec) {
+            $out[$spec->requestName] = $spec->args;
+        }
+
+        return $out;
+    }
+
+    /**
      * @return Route[]
      */
     private function invokeGetRoutes(RouteLoader $loader): array
@@ -162,6 +262,19 @@ class RouteLoaderTest extends TestCase
         /** @var Route[] $routes */
         $routes = $method->invoke($loader);
         return $routes;
+    }
+
+    /**
+     * @return array<array<string, mixed>>
+     */
+    private function invokeBuildRouteArgs(RouteLoader $loader, Route $route): array
+    {
+        $method = new \ReflectionMethod(RouteLoader::class, 'buildRouteArgs');
+        $method->setAccessible(true);
+
+        /** @var array<array<string, mixed>> $args */
+        $args = $method->invoke($loader, $route);
+        return $args;
     }
 }
 

--- a/tests/Unit/fixtures/Loaders/SortDirection.php
+++ b/tests/Unit/fixtures/Loaders/SortDirection.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpRestApi\Tests\Unit\fixtures\Loaders;
+
+enum SortDirection: string
+{
+    case Asc = 'asc';
+    case Desc = 'desc';
+}

--- a/tests/Unit/fixtures/Loaders/WithEnumParam/RouteWithEnumParam.php
+++ b/tests/Unit/fixtures/Loaders/WithEnumParam/RouteWithEnumParam.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpRestApi\Tests\Unit\fixtures\Loaders\WithEnumParam;
+
+use Dbout\WpRestApi\Attributes\Action;
+use Dbout\WpRestApi\Attributes\Param;
+use Dbout\WpRestApi\Attributes\Route;
+use Dbout\WpRestApi\Enums\Method;
+use Dbout\WpRestApi\Tests\Unit\fixtures\Loaders\SortDirection;
+
+#[Route('loader-test/v1', '/sorted')]
+class RouteWithEnumParam
+{
+    #[Action(Method::GET)]
+    public function list(
+        #[Param(required: true)]
+        SortDirection $direction,
+    ): \WP_REST_Response {
+        return new \WP_REST_Response(['direction' => $direction->value]);
+    }
+}

--- a/tests/Unit/fixtures/Loaders/WithParams/RouteWithParams.php
+++ b/tests/Unit/fixtures/Loaders/WithParams/RouteWithParams.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpRestApi\Tests\Unit\fixtures\Loaders\WithParams;
+
+use Dbout\WpRestApi\Attributes\Action;
+use Dbout\WpRestApi\Attributes\Param;
+use Dbout\WpRestApi\Attributes\Route;
+use Dbout\WpRestApi\Enums\Method;
+
+#[Route('loader-test/v1', '/items')]
+class RouteWithParams
+{
+    #[Action(Method::GET)]
+    public function show(
+        #[Param(required: true, description: 'Item identifier')]
+        int $id,
+        #[Param(default: 10)]
+        int $perPage = 10,
+        #[Param(name: 'q')]
+        ?string $search = null,
+    ): \WP_REST_Response {
+        return new \WP_REST_Response(['id' => $id, 'perPage' => $perPage, 'search' => $search]);
+    }
+}

--- a/tests/WordPress/RouteLoaderIntegrationTest.php
+++ b/tests/WordPress/RouteLoaderIntegrationTest.php
@@ -90,6 +90,55 @@ class RouteLoaderIntegrationTest extends \WP_UnitTestCase
         $this->assertSame('Resource not found.', $error['message']);
     }
 
+    public function testRequiredParamIsEnforcedByWordPress(): void
+    {
+        (new RouteLoader(self::FIXTURES_DIR . '/ParamRoute'))->register();
+        do_action('rest_api_init');
+
+        $missing = rest_do_request(new \WP_REST_Request('GET', '/integration/v1/articles'));
+        $this->assertSame(
+            400,
+            $missing->get_status(),
+            'WordPress MUST reject the call with 400 when a required #[Param] is missing.'
+        );
+
+        $request = new \WP_REST_Request('GET', '/integration/v1/articles');
+        $request->set_param('id', '42'); // strings from query strings, absint coerces.
+        $ok = rest_do_request($request);
+
+        $this->assertSame(200, $ok->get_status());
+        $this->assertSame(['id' => 42], $ok->get_data());
+    }
+
+    public function testRequiredParamIsHonoredOnPostJsonBody(): void
+    {
+        (new RouteLoader(self::FIXTURES_DIR . '/PostBodyParamRoute'))->register();
+        do_action('rest_api_init');
+
+        $missing = rest_do_request(new \WP_REST_Request('POST', '/integration/v1/articles/create'));
+        $this->assertSame(
+            400,
+            $missing->get_status(),
+            'WordPress MUST reject the POST when a required #[Param] is missing from every source.'
+        );
+
+        $jsonRequest = new \WP_REST_Request('POST', '/integration/v1/articles/create');
+        $jsonRequest->set_header('content-type', 'application/json');
+        $jsonRequest->set_body((string) json_encode(['id' => 7, 'title' => 'Hello']));
+        $jsonResponse = rest_do_request($jsonRequest);
+
+        $this->assertSame(201, $jsonResponse->get_status(), 'JSON body params should reach the handler.');
+        $this->assertSame(['id' => 7, 'title' => 'Hello'], $jsonResponse->get_data());
+
+        // Same route, form-encoded body — also resolves via has_param/get_param.
+        $formRequest = new \WP_REST_Request('POST', '/integration/v1/articles/create');
+        $formRequest->set_body_params(['id' => '12', 'title' => 'Form']);
+        $formResponse = rest_do_request($formRequest);
+
+        $this->assertSame(201, $formResponse->get_status());
+        $this->assertSame(['id' => 12, 'title' => 'Form'], $formResponse->get_data());
+    }
+
     public function testProblemJsonFormatterIsUsedWhenConfigured(): void
     {
         $options = new RouteLoaderOptions(errorFormatter: new ProblemJsonFormatter());

--- a/tests/WordPress/fixtures/ParamRoute/ParamRoute.php
+++ b/tests/WordPress/fixtures/ParamRoute/ParamRoute.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpRestApi\Tests\WordPress\fixtures\ParamRoute;
+
+use Dbout\WpRestApi\Attributes\Action;
+use Dbout\WpRestApi\Attributes\Param;
+use Dbout\WpRestApi\Attributes\Route;
+use Dbout\WpRestApi\Enums\Method;
+
+#[Route('integration/v1', '/articles')]
+class ParamRoute
+{
+    #[Action(Method::GET)]
+    public function show(
+        #[Param(required: true, description: 'Article identifier')]
+        int $id,
+    ): \WP_REST_Response {
+        return new \WP_REST_Response(['id' => $id]);
+    }
+}

--- a/tests/WordPress/fixtures/PostBodyParamRoute/PostBodyParamRoute.php
+++ b/tests/WordPress/fixtures/PostBodyParamRoute/PostBodyParamRoute.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpRestApi\Tests\WordPress\fixtures\PostBodyParamRoute;
+
+use Dbout\WpRestApi\Attributes\Action;
+use Dbout\WpRestApi\Attributes\Param;
+use Dbout\WpRestApi\Attributes\Route;
+use Dbout\WpRestApi\Enums\Method;
+
+#[Route('integration/v1', '/articles/create')]
+class PostBodyParamRoute
+{
+    #[Action(Method::POST)]
+    public function create(
+        #[Param(required: true)]
+        int $id,
+        #[Param(required: true)]
+        string $title,
+    ): \WP_REST_Response {
+        return new \WP_REST_Response(['id' => $id, 'title' => $title], 201);
+    }
+}


### PR DESCRIPTION
## Summary

Add `#[Param]` attribute on handler parameters so the args schema is compiled into WordPress's `register_rest_route` instead of being re-implemented inside every handler. WordPress now enforces `required` / `type` / `enum` / `sanitize_callback` before the handler runs, and the auto-discovery endpoint  (`/wp-json/<ns>`) describes the route arguments.

## Why

`RouteLoader::buildRouteArgs()` was always emitting `'args' => []`, so:
  
- Validation had to be duplicated in every handler.
- Misuse (missing required field) hit the handler before being rejected.
- The discovery endpoint exposed nothing useful to API consumers.

## Usage

  ```php
  #[Route('blog/v1', '/articles/(?P<id>\d+)')]
  class ArticleRoute
  {
      #[Action(Method::GET)]
      public function show(
          #[Param(required: true, description: 'Article identifier')]
          int $id,
          #[Param(default: 10, enum: [10, 25, 50])]
          int $perPage,
      ): \WP_REST_Response { ... }
  }
```

  Compiled into:
  
```
  'args' => [
      'id' => [
          'type' => 'integer',
          'required' => true,
          'description' => 'Article identifier',
          'sanitize_callback' => 'absint',
      ],
      'perPage' => [
          'type' => 'integer',
          'default' => 10,
          'enum' => [10, 25, 50],
          'sanitize_callback' => 'absint',
      ],
  ]
```
  
  Type inference (when Param::$type is null)

**Backward compatibility**
  
Handlers without `#[Param]` keep registering with empty args — nothing else changes.