### PR TITLE
✨ Add NamespaceRouteLoader powered by Composer's PSR-4 map

### DIFF
--- a/src/NamespaceRouteLoader.php
+++ b/src/NamespaceRouteLoader.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpRestApi;
+
+use Composer\Autoload\ClassLoader;
+use Dbout\WpRestApi\Exceptions\ApiException;
+use Dbout\WpRestApi\Loaders\AnnotatedRouteRestLoader;
+
+/**
+ * Namespace-based route discovery.
+ *
+ * Resolves the filesystem directory(ies) attached to a PSR-4 namespace
+ * prefix via Composer's autoloader, derives each candidate class' FQCN
+ * from its file path (no token parsing), and delegates the attribute
+ * inspection to {@see AnnotatedRouteRestLoader}.
+ *
+ * Compared to the legacy {@see RouteLoader} directory mode, this avoids
+ * the custom token-stream parser and trusts Composer as the single
+ * source of truth for the class-to-file mapping.
+ *
+ * @api
+ */
+class NamespaceRouteLoader extends RouteLoader
+{
+    /** @var string[] Normalized namespace prefixes (always trailing "\\"). */
+    protected array $namespaces;
+
+    protected ClassLoader $classLoader;
+
+    protected AnnotatedRouteRestLoader $annotationLoader;
+
+    /**
+     * @param string|string[] $namespace One or more PSR-4 namespace prefixes
+     *                                    to scan (e.g. `App\Routes\`).
+     * @param RouteLoaderOptions|null $options
+     * @param ClassLoader|null $classLoader Optional Composer ClassLoader override.
+     *                                       Defaults to the first registered loader.
+     */
+    public function __construct(
+        string|array $namespace,
+        ?RouteLoaderOptions $options = null,
+        ?ClassLoader $classLoader = null,
+    ) {
+        // The parent constructor stores $routeDirectory; we never read it
+        // because we override findRoutes(). Pass an empty array to keep the
+        // contract honest.
+        parent::__construct([], $options);
+
+        $this->namespaces = array_values(array_map(
+            static fn (string $ns): string => rtrim($ns, '\\') . '\\',
+            is_array($namespace) ? $namespace : [$namespace],
+        ));
+        $this->classLoader = $classLoader ?? self::resolveDefaultClassLoader();
+        $this->annotationLoader = new AnnotatedRouteRestLoader();
+    }
+
+    /**
+     * @throws ApiException When no Composer ClassLoader is registered.
+     * @return ClassLoader
+     */
+    protected static function resolveDefaultClassLoader(): ClassLoader
+    {
+        $loaders = ClassLoader::getRegisteredLoaders();
+        if ($loaders === []) {
+            throw new ApiException(
+                'No Composer ClassLoader is registered. Did you require vendor/autoload.php?',
+            );
+        }
+
+        return reset($loaders);
+    }
+
+    /**
+     * @return Route[]
+     * @throws \ReflectionException|ApiException
+     */
+    protected function findRoutes(): array
+    {
+        $routes = [];
+        foreach ($this->namespaces as $namespace) {
+            foreach ($this->discoverClasses($namespace) as $fqcn) {
+                if (!class_exists($fqcn)) {
+                    continue;
+                }
+
+                $reflection = new \ReflectionClass($fqcn);
+                if ($reflection->isAbstract()) {
+                    continue;
+                }
+
+                $route = $this->annotationLoader->load($fqcn);
+                if ($route instanceof Route) {
+                    $routes[] = $route;
+                }
+            }
+        }
+
+        $this->checkRoutes($routes);
+        return $routes;
+    }
+
+    /**
+     * Walks the directory bound to the longest registered PSR-4 prefix that
+     * is a prefix of $namespace, and yields the FQCN of every PHP file
+     * found underneath.
+     *
+     * @return iterable<string>
+     */
+    protected function discoverClasses(string $namespace): iterable
+    {
+        $directories = $this->resolveDirectoriesFor($namespace);
+        foreach ($directories as $directory) {
+            if (!is_dir($directory)) {
+                continue;
+            }
+
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveCallbackFilterIterator(
+                    new \RecursiveDirectoryIterator(
+                        $directory,
+                        \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::FOLLOW_SYMLINKS,
+                    ),
+                    static fn (\SplFileInfo $current): bool => !str_starts_with($current->getBasename(), '.'),
+                ),
+                \RecursiveIteratorIterator::LEAVES_ONLY,
+            );
+
+            $basePath = rtrim((string) realpath($directory), DIRECTORY_SEPARATOR);
+            foreach ($iterator as $file) {
+                /** @var \SplFileInfo $file */
+                if (!$file->isFile() || $file->getExtension() !== 'php') {
+                    continue;
+                }
+
+                $real = $file->getRealPath();
+                if ($real === false) {
+                    continue;
+                }
+
+                $relative = substr($real, strlen($basePath) + 1, -4);
+                $suffix = str_replace(DIRECTORY_SEPARATOR, '\\', $relative);
+                yield $namespace . $suffix;
+            }
+        }
+    }
+
+    /**
+     * Resolve filesystem directories for a namespace by finding the longest
+     * registered PSR-4 prefix that matches and appending the remaining
+     * sub-namespace as a relative path.
+     *
+     * @return string[]
+     */
+    protected function resolveDirectoriesFor(string $namespace): array
+    {
+        $psr4 = $this->classLoader->getPrefixesPsr4();
+
+        $longest = '';
+        foreach (array_keys($psr4) as $prefix) {
+            if (str_starts_with($namespace, $prefix) && strlen($prefix) > strlen($longest)) {
+                $longest = $prefix;
+            }
+        }
+
+        if ($longest === '') {
+            return [];
+        }
+
+        $subPath = str_replace('\\', DIRECTORY_SEPARATOR, substr($namespace, strlen($longest)));
+        $subPath = rtrim($subPath, DIRECTORY_SEPARATOR);
+
+        return array_map(
+            static function (string $base) use ($subPath): string {
+                $base = rtrim($base, DIRECTORY_SEPARATOR);
+                return $subPath === '' ? $base : $base . DIRECTORY_SEPARATOR . $subPath;
+            },
+            $psr4[$longest],
+        );
+    }
+}

--- a/src/NamespaceRouteLoader.php
+++ b/src/NamespaceRouteLoader.php
@@ -77,8 +77,8 @@ class NamespaceRouteLoader extends RouteLoader
     }
 
     /**
-     * @return Route[]
      * @throws \ReflectionException|ApiException
+     * @return Route[]
      */
     protected function findRoutes(): array
     {

--- a/src/RouteLoader.php
+++ b/src/RouteLoader.php
@@ -22,6 +22,11 @@ class RouteLoader
     /**
      * @param string|array<string> $routeDirectory
      * @param RouteLoaderOptions|null $options
+     *
+     * @deprecated Directory-based discovery relies on a custom token parser
+     *             that has known edge cases (anonymous classes, block-style
+     *             namespaces). Prefer {@see NamespaceRouteLoader} which uses
+     *             Composer's PSR-4 mapping as the source of truth.
      */
     public function __construct(
         protected string|array $routeDirectory,

--- a/tests/Unit/Loaders/AnnotatedRouteRestLoaderTest.php
+++ b/tests/Unit/Loaders/AnnotatedRouteRestLoaderTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpRestApi\Tests\Unit\Loaders;
+
+use Dbout\WpRestApi\Loaders\AnnotatedRouteRestLoader;
+use Dbout\WpRestApi\ParamSpec;
+use Dbout\WpRestApi\Route;
+use Dbout\WpRestApi\Tests\Unit\fixtures\Loaders\SortDirection;
+use Dbout\WpRestApi\Tests\Unit\fixtures\Loaders\WithEnumParam\RouteWithEnumParam;
+use Dbout\WpRestApi\Tests\Unit\fixtures\Loaders\WithParams\RouteWithParams;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Dbout\WpRestApi\Loaders\AnnotatedRouteRestLoader
+ */
+class AnnotatedRouteRestLoaderTest extends TestCase
+{
+    /**
+     * @covers ::collectParams
+     * @covers ::compileParam
+     * @covers ::inferWpType
+     * @covers ::inferSanitizeCallback
+     */
+    public function testParamAttributeIsCollected(): void
+    {
+        $route = (new AnnotatedRouteRestLoader())->load(RouteWithParams::class);
+
+        $this->assertInstanceOf(Route::class, $route);
+        $this->assertCount(1, $route->actions);
+
+        $params = $route->actions[0]->params;
+        $this->assertCount(3, $params, 'Each #[Param]-annotated argument must produce a ParamSpec.');
+
+        $byRequestName = [];
+        foreach ($params as $spec) {
+            $this->assertInstanceOf(ParamSpec::class, $spec);
+            $byRequestName[$spec->requestName] = $spec;
+        }
+
+        $this->assertSame('id', $byRequestName['id']->phpName);
+        $this->assertSame([
+            'type' => 'integer',
+            'required' => true,
+            'description' => 'Item identifier',
+            'sanitize_callback' => 'absint',
+        ], $byRequestName['id']->args);
+
+        $this->assertSame([
+            'type' => 'integer',
+            'default' => 10,
+            'sanitize_callback' => 'absint',
+        ], $byRequestName['perPage']->args);
+
+        $this->assertSame(
+            'search',
+            $byRequestName['q']->phpName,
+            'Param::$name must override the request key while the PHP name stays accessible for injection.'
+        );
+        $this->assertSame('sanitize_text_field', $byRequestName['q']->args['sanitize_callback']);
+    }
+
+    /**
+     * @covers ::compileParam
+     * @covers ::inferWpType
+     * @covers ::inferEnumFromBackedEnum
+     */
+    public function testBackedEnumParameterAutoPopulatesEnumValues(): void
+    {
+        $route = (new AnnotatedRouteRestLoader())->load(RouteWithEnumParam::class);
+
+        $this->assertInstanceOf(Route::class, $route);
+        $params = $route->actions[0]->params;
+        $this->assertCount(1, $params);
+
+        $spec = $params[0];
+        $this->assertSame('string', $spec->args['type']);
+        $this->assertSame(
+            [SortDirection::Asc->value, SortDirection::Desc->value],
+            $spec->args['enum'],
+            'BackedEnum cases must be unrolled to their backing values.'
+        );
+        $this->assertTrue($spec->args['required']);
+    }
+}

--- a/tests/Unit/NamespaceRouteLoaderTest.php
+++ b/tests/Unit/NamespaceRouteLoaderTest.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpRestApi\Tests\Unit;
+
+use Composer\Autoload\ClassLoader;
+use Dbout\WpRestApi\NamespaceRouteLoader;
+use Dbout\WpRestApi\Route;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Dbout\WpRestApi\NamespaceRouteLoader
+ */
+class NamespaceRouteLoaderTest extends TestCase
+{
+    private const FIXTURE_NS = 'Dbout\\WpRestApi\\Tests\\Unit\\fixtures\\NamespaceLoader\\';
+
+    /**
+     * @covers ::findRoutes
+     * @covers ::discoverClasses
+     * @covers ::resolveDirectoriesFor
+     */
+    public function testDiscoversRoutesFromPsr4Namespace(): void
+    {
+        $loader = new NamespaceRouteLoader(self::FIXTURE_NS . 'Pings\\');
+
+        $routes = $this->invokeGetRoutes($loader);
+
+        $byPath = [];
+        foreach ($routes as $route) {
+            $byPath[$route->path] = $route;
+        }
+
+        $this->assertArrayHasKey('/ping', $byPath);
+        $this->assertArrayHasKey('/pong', $byPath);
+        $this->assertSame('namespace-loader/v1', $byPath['/ping']->namespace);
+    }
+
+    /**
+     * @covers ::resolveDirectoriesFor
+     */
+    public function testLongestPsr4PrefixWins(): void
+    {
+        $classLoader = new ClassLoader();
+        $classLoader->addPsr4(
+            'Dbout\\WpRestApi\\Tests\\',
+            __DIR__ . '/..',
+        );
+        // A wider, less-specific prefix that must NOT be picked.
+        $classLoader->addPsr4(
+            'Dbout\\',
+            __DIR__ . '/../../src',
+        );
+
+        $loader = new NamespaceRouteLoader(self::FIXTURE_NS . 'Pings\\', null, $classLoader);
+        $routes = $this->invokeGetRoutes($loader);
+
+        $paths = array_map(static fn (Route $r): string => $r->path, $routes);
+        sort($paths);
+        $this->assertSame(
+            ['/ping', '/pong'],
+            $paths,
+            'Longest matching prefix should resolve the fixture directory, not the wider Dbout\\ prefix.',
+        );
+    }
+
+    /**
+     * @covers ::findRoutes
+     * @covers ::discoverClasses
+     */
+    public function testClassesWithoutRouteAttributeAreSkipped(): void
+    {
+        $loader = new NamespaceRouteLoader(self::FIXTURE_NS . 'NotRoutes\\');
+
+        $routes = $this->invokeGetRoutes($loader);
+        $this->assertSame(
+            [],
+            $routes,
+            'NamespaceRouteLoader must not surface classes without #[Route], and must drop abstract ones.',
+        );
+    }
+
+    /**
+     * @covers ::resolveDirectoriesFor
+     */
+    public function testUnknownNamespaceReturnsEmpty(): void
+    {
+        $classLoader = new ClassLoader();
+        // Intentionally no PSR-4 entry registered.
+
+        $loader = new NamespaceRouteLoader('Acme\\Nothing\\', null, $classLoader);
+
+        $this->assertSame([], $this->invokeGetRoutes($loader));
+    }
+
+    /**
+     * @covers ::__construct
+     */
+    public function testAcceptsMultipleNamespaces(): void
+    {
+        $loader = new NamespaceRouteLoader([
+            self::FIXTURE_NS . 'Pings\\',
+            self::FIXTURE_NS . 'NotRoutes\\',
+        ]);
+
+        $routes = $this->invokeGetRoutes($loader);
+        $paths = array_map(static fn (Route $r): string => $r->path, $routes);
+        sort($paths);
+        $this->assertSame(['/ping', '/pong'], $paths);
+    }
+
+    /**
+     * @return Route[]
+     */
+    private function invokeGetRoutes(NamespaceRouteLoader $loader): array
+    {
+        $method = new \ReflectionMethod(\Dbout\WpRestApi\RouteLoader::class, 'getRoutes');
+        $method->setAccessible(true);
+
+        /** @var Route[] $routes */
+        $routes = $method->invoke($loader);
+        return $routes;
+    }
+}

--- a/tests/Unit/fixtures/NamespaceLoader/NotRoutes/AbstractRoute.php
+++ b/tests/Unit/fixtures/NamespaceLoader/NotRoutes/AbstractRoute.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpRestApi\Tests\Unit\fixtures\NamespaceLoader\NotRoutes;
+
+use Dbout\WpRestApi\Attributes\Action;
+use Dbout\WpRestApi\Attributes\Route;
+use Dbout\WpRestApi\Enums\Method;
+
+#[Route('namespace-loader/v1', '/abstract')]
+abstract class AbstractRoute
+{
+    #[Action(Method::GET)]
+    abstract public function get(): \WP_REST_Response;
+}

--- a/tests/Unit/fixtures/NamespaceLoader/NotRoutes/PlainService.php
+++ b/tests/Unit/fixtures/NamespaceLoader/NotRoutes/PlainService.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpRestApi\Tests\Unit\fixtures\NamespaceLoader\NotRoutes;
+
+/**
+ * Intentionally has no #[Route] attribute: NamespaceRouteLoader must skip it
+ * even though it lives under the scanned namespace.
+ */
+class PlainService
+{
+    public function nothingToSeeHere(): void
+    {
+    }
+}

--- a/tests/Unit/fixtures/NamespaceLoader/Pings/PingRoute.php
+++ b/tests/Unit/fixtures/NamespaceLoader/Pings/PingRoute.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpRestApi\Tests\Unit\fixtures\NamespaceLoader\Pings;
+
+use Dbout\WpRestApi\Attributes\Action;
+use Dbout\WpRestApi\Attributes\Route;
+use Dbout\WpRestApi\Enums\Method;
+
+#[Route('namespace-loader/v1', '/ping')]
+class PingRoute
+{
+    #[Action(Method::GET)]
+    public function ping(): \WP_REST_Response
+    {
+        return new \WP_REST_Response(['pong' => true]);
+    }
+}

--- a/tests/Unit/fixtures/NamespaceLoader/Pings/PongRoute.php
+++ b/tests/Unit/fixtures/NamespaceLoader/Pings/PongRoute.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpRestApi\Tests\Unit\fixtures\NamespaceLoader\Pings;
+
+use Dbout\WpRestApi\Attributes\Action;
+use Dbout\WpRestApi\Attributes\Route;
+use Dbout\WpRestApi\Enums\Method;
+
+#[Route('namespace-loader/v1', '/pong')]
+class PongRoute
+{
+    #[Action(Method::GET)]
+    public function pong(): \WP_REST_Response
+    {
+        return new \WP_REST_Response(['ping' => true]);
+    }
+}

--- a/tests/WordPress/RouteLoaderIntegrationTest.php
+++ b/tests/WordPress/RouteLoaderIntegrationTest.php
@@ -9,6 +9,7 @@
 namespace Dbout\WpRestApi\Tests\WordPress;
 
 use Dbout\WpRestApi\ErrorFormat\ProblemJsonFormatter;
+use Dbout\WpRestApi\NamespaceRouteLoader;
 use Dbout\WpRestApi\RouteLoader;
 use Dbout\WpRestApi\RouteLoaderOptions;
 
@@ -108,6 +109,19 @@ class RouteLoaderIntegrationTest extends \WP_UnitTestCase
 
         $this->assertSame(200, $ok->get_status());
         $this->assertSame(['id' => 42], $ok->get_data());
+    }
+
+    public function testNamespaceLoaderRegistersRoutesViaComposer(): void
+    {
+        (new NamespaceRouteLoader(
+            'Dbout\\WpRestApi\\Tests\\WordPress\\fixtures\\NamespaceLoaderRoute\\',
+        ))->register();
+        do_action('rest_api_init');
+
+        $response = rest_do_request(new \WP_REST_Request('GET', '/integration/v1/namespace-ping'));
+
+        $this->assertSame(200, $response->get_status());
+        $this->assertSame(['source' => 'namespace-loader'], $response->get_data());
     }
 
     public function testRequiredParamIsHonoredOnPostJsonBody(): void

--- a/tests/WordPress/fixtures/NamespaceLoaderRoute/PingRoute.php
+++ b/tests/WordPress/fixtures/NamespaceLoaderRoute/PingRoute.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Dimitri BOUTEILLE <bonjour@dimitri-bouteille.fr>
+ */
+
+namespace Dbout\WpRestApi\Tests\WordPress\fixtures\NamespaceLoaderRoute;
+
+use Dbout\WpRestApi\Attributes\Action;
+use Dbout\WpRestApi\Attributes\Route;
+use Dbout\WpRestApi\Enums\Method;
+
+#[Route('integration/v1', '/namespace-ping')]
+class PingRoute
+{
+    #[Action(Method::GET)]
+    public function ping(): \WP_REST_Response
+    {
+        return new \WP_REST_Response(['source' => 'namespace-loader']);
+    }
+}


### PR DESCRIPTION
### Summary

Add `NamespaceRouteLoader`, a Composer-powered route discoverer, and mark the directory-based `RouteLoader::__construct` as `@deprecated`. The new loader resolves the filesystem location of routes from Composer's PSR-4 map and derives each candidate FQCN from its file path, so the custom token-stream parser becomes optional going forward.

### Why
  
`RouteLoader` discovery currently relies on `Parser::findClassName`, a hand-rolled tokenizer that has several known edge cases (anonymous classes hijacking detection, block-style namespaces missed, missing early-exit). Composer already knows the class-to-file mapping via PSR-4, so re-implementing that lookup with `token_get_all` duplicates work and introduces bugs.

`NamespaceRouteLoader` swaps the convention: users declare the **namespace** they want to expose, the loader asks Composer where that namespace lives on disk, walks the directory, and derives each FQCN from the path. No tokenizing, no `Parser` invocation.

### Usage

```php
  use Dbout\WpRestApi\NamespaceRouteLoader;

  (new NamespaceRouteLoader('App\\Routes\\'))->register();
```

Or, with options and an injected ClassLoader (useful for tests or  multi-autoloader setups):

```php
  $loader = new NamespaceRouteLoader(
      ['App\\Routes\\', 'App\\Admin\\Routes\\'],
      new RouteLoaderOptions(cache: $cache),
      $composerClassLoader,
  );
```

### Deprecation

`RouteLoader::__construct` carries an @deprecated PHPDoc tag pointing at NamespaceRouteLoader. Behaviour is unchanged at runtime — existing code keeps working — but PHPStan and IDEs will flag direct instantiation. The class itself stays as the base class NamespaceRouteLoader inherits from.

### Backward compatibility

Non-breaking, minor bump. RouteLoader still discovers routes via the directory walker + Parser. Nothing was removed.